### PR TITLE
chore: bump ESI compatibility date to 2026-06-09

### DIFF
--- a/config/esi.php
+++ b/config/esi.php
@@ -14,5 +14,5 @@ return [
         'delay' => 5000,
     ],
     'base_url' => 'https://esi.evetech.net',
-    'compatibility_date' => '2026-05-19',
+    'compatibility_date' => '2026-06-09',
 ];

--- a/tests/ContactsTest.php
+++ b/tests/ContactsTest.php
@@ -56,14 +56,6 @@ function fakeContactCharacter(): Character
     };
 }
 
-beforeEach(function (): void {
-    config()->set('esi.base_url', 'https://esi.evetech.net');
-    config()->set('esi.compatibility_date', '2026-05-19');
-    config()->set('esi.user_agent', 'esi-test');
-    config()->set('esi.retry_policy.tries', 1);
-    config()->set('esi.retry_policy.delay', 0);
-});
-
 it('fetches and maps character contacts', function (): void {
     Http::fake([
         'esi.evetech.net/characters/123/contacts/*' => Http::response([

--- a/tests/UniverseIdsTest.php
+++ b/tests/UniverseIdsTest.php
@@ -7,14 +7,6 @@ use NicolasKion\Esi\DTO\UniverseId;
 use NicolasKion\Esi\DTO\UniverseIds;
 use NicolasKion\Esi\Esi;
 
-beforeEach(function (): void {
-    config()->set('esi.base_url', 'https://esi.evetech.net');
-    config()->set('esi.compatibility_date', '2026-05-19');
-    config()->set('esi.user_agent', 'esi-test');
-    config()->set('esi.retry_policy.tries', 1);
-    config()->set('esi.retry_policy.delay', 0);
-});
-
 it('resolves names to ids grouped by category', function (): void {
     Http::fake([
         'esi.evetech.net/universe/ids/*' => Http::response([


### PR DESCRIPTION
Follow-up to #19. Aligns `config/esi.php` with the `2026-06-09` schema the
DTOs, requests and fixtures were built against (the sovereignty endpoint
change and updated DTO shapes come from that compatibility date), and drops
the now-redundant per-file config in `ContactsTest`/`UniverseIdsTest`.