### PR TITLE
refactor: pin ESI compatibility date to a version constant

### DIFF
--- a/config/esi.php
+++ b/config/esi.php
@@ -14,5 +14,4 @@ return [
         'delay' => 5000,
     ],
     'base_url' => 'https://esi.evetech.net',
-    'compatibility_date' => '2026-06-09',
 ];

--- a/src/Connector.php
+++ b/src/Connector.php
@@ -22,6 +22,8 @@ use function config;
 
 class Connector
 {
+    public const COMPATIBILITY_DATE = '2026-06-09';
+
     public const ERROR_LIMIT_REMAIN_HEADER = 'X-Esi-Error-Limit-Remain';
 
     public const ERROR_LIMIT_RESET_HEADER = 'X-Esi-Error-Limit-Reset';
@@ -56,7 +58,7 @@ class Connector
 
         $pending_request = Http::withHeaders([
             'User-Agent' => config()->string('esi.user_agent'),
-            'X-Compatibility-Date' => config()->string('esi.compatibility_date'),
+            'X-Compatibility-Date' => self::COMPATIBILITY_DATE,
         ])
             ->baseUrl(config()->string('esi.base_url'))
             ->when(count($request->getQuery()), fn (PendingRequest $r) => $r->withQueryParameters($request->getQuery()))
@@ -114,7 +116,7 @@ class Connector
 
             $pending_request = Http::withHeaders([
                 'User-Agent' => config()->string('esi.user_agent'),
-                'X-Compatibility-Date' => config()->string('esi.compatibility_date'),
+                'X-Compatibility-Date' => self::COMPATIBILITY_DATE,
             ])
                 ->baseUrl(config()->string('esi.base_url'))
                 ->when(count($request->getQuery()), fn (PendingRequest $r) => $r->withQueryParameters($request->getQuery()))

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -20,7 +20,6 @@ uses(TestCase::class)->in(__DIR__);
 */
 uses()->beforeEach(function (): void {
     config()->set('esi.base_url', 'https://esi.evetech.net');
-    config()->set('esi.compatibility_date', '2026-06-09');
     config()->set('esi.user_agent', 'esi-test');
     config()->set('esi.retry_policy.tries', 1);
     config()->set('esi.retry_policy.delay', 0);


### PR DESCRIPTION
The published Laravel `config/esi.php` is copied into an app once and never updates on package upgrade, so a hardcoded `compatibility_date` there goes stale — while the DTOs/fixtures are built against a specific schema date. Moves it to `Connector::COMPATIBILITY_DATE` (updates with the package) and drops the config key.