### PR TITLE
feat: add dogma attribute and effect endpoints

### DIFF
--- a/src/DTO/DogmaAttribute.php
+++ b/src/DTO/DogmaAttribute.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\DTO;
+
+use NicolasKion\Esi\Support\Data;
+
+readonly class DogmaAttribute extends Dto
+{
+    public function __construct(
+        public int $attribute_id,
+        public ?float $default_value,
+        public ?string $description,
+        public ?string $display_name,
+        public ?bool $high_is_good,
+        public ?int $icon_id,
+        public ?string $name,
+        public ?bool $published,
+        public ?bool $stackable,
+        public ?int $unit_id,
+    ) {}
+
+    public static function fromData(Data $data): self
+    {
+        return new self(
+            attribute_id: $data->integer('attribute_id', 0),
+            default_value: $data->float('default_value'),
+            description: $data->string('description'),
+            display_name: $data->string('display_name'),
+            high_is_good: $data->boolean('high_is_good'),
+            icon_id: $data->integer('icon_id'),
+            name: $data->string('name'),
+            published: $data->boolean('published'),
+            stackable: $data->boolean('stackable'),
+            unit_id: $data->integer('unit_id'),
+        );
+    }
+}

--- a/src/DTO/DogmaEffect.php
+++ b/src/DTO/DogmaEffect.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\DTO;
+
+use NicolasKion\Esi\Support\Data;
+
+readonly class DogmaEffect extends Dto
+{
+    /**
+     * @param  array<int, DogmaEffectModifier>  $modifiers
+     */
+    public function __construct(
+        public int $effect_id,
+        public ?string $description,
+        public ?bool $disallow_auto_repeat,
+        public ?int $discharge_attribute_id,
+        public ?string $display_name,
+        public ?int $duration_attribute_id,
+        public ?int $effect_category,
+        public ?bool $electronic_chance,
+        public ?int $falloff_attribute_id,
+        public ?int $icon_id,
+        public ?bool $is_assistance,
+        public ?bool $is_offensive,
+        public ?bool $is_warp_safe,
+        public array $modifiers,
+        public ?string $name,
+        public ?int $post_expression,
+        public ?int $pre_expression,
+        public ?bool $published,
+        public ?int $range_attribute_id,
+        public ?bool $range_chance,
+        public ?int $tracking_speed_attribute_id,
+    ) {}
+
+    public static function fromData(Data $data): self
+    {
+        return new self(
+            effect_id: $data->integer('effect_id', 0),
+            description: $data->string('description'),
+            disallow_auto_repeat: $data->boolean('disallow_auto_repeat'),
+            discharge_attribute_id: $data->integer('discharge_attribute_id'),
+            display_name: $data->string('display_name'),
+            duration_attribute_id: $data->integer('duration_attribute_id'),
+            effect_category: $data->integer('effect_category'),
+            electronic_chance: $data->boolean('electronic_chance'),
+            falloff_attribute_id: $data->integer('falloff_attribute_id'),
+            icon_id: $data->integer('icon_id'),
+            is_assistance: $data->boolean('is_assistance'),
+            is_offensive: $data->boolean('is_offensive'),
+            is_warp_safe: $data->boolean('is_warp_safe'),
+            modifiers: $data->list('modifiers', DogmaEffectModifier::fromData(...)),
+            name: $data->string('name'),
+            post_expression: $data->integer('post_expression'),
+            pre_expression: $data->integer('pre_expression'),
+            published: $data->boolean('published'),
+            range_attribute_id: $data->integer('range_attribute_id'),
+            range_chance: $data->boolean('range_chance'),
+            tracking_speed_attribute_id: $data->integer('tracking_speed_attribute_id'),
+        );
+    }
+}

--- a/src/DTO/DogmaEffectModifier.php
+++ b/src/DTO/DogmaEffectModifier.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\DTO;
+
+use NicolasKion\Esi\Support\Data;
+
+readonly class DogmaEffectModifier extends Dto
+{
+    public function __construct(
+        public ?string $domain,
+        public ?int $effect_id,
+        public ?string $func,
+        public ?int $modified_attribute_id,
+        public ?int $modifying_attribute_id,
+        public ?int $operator,
+    ) {}
+
+    public static function fromData(Data $data): self
+    {
+        return new self(
+            domain: $data->string('domain'),
+            effect_id: $data->integer('effect_id'),
+            func: $data->string('func'),
+            modified_attribute_id: $data->integer('modified_attribute_id'),
+            modifying_attribute_id: $data->integer('modifying_attribute_id'),
+            operator: $data->integer('operator'),
+        );
+    }
+}

--- a/src/Esi.php
+++ b/src/Esi.php
@@ -16,6 +16,8 @@ use NicolasKion\Esi\DTO\ContactLabel;
 use NicolasKion\Esi\DTO\Corporation;
 use NicolasKion\Esi\DTO\CorporationDivisions;
 use NicolasKion\Esi\DTO\CorporationStructure;
+use NicolasKion\Esi\DTO\DogmaAttribute;
+use NicolasKion\Esi\DTO\DogmaEffect;
 use NicolasKion\Esi\DTO\DogmaItem;
 use NicolasKion\Esi\DTO\EsiResult;
 use NicolasKion\Esi\DTO\EveMail;
@@ -59,6 +61,10 @@ use NicolasKion\Esi\Requests\GetCorporationContactsRequest;
 use NicolasKion\Esi\Requests\GetCorporationDivisionsRequest;
 use NicolasKion\Esi\Requests\GetCorporationRequest;
 use NicolasKion\Esi\Requests\GetCorporationStructuresRequest;
+use NicolasKion\Esi\Requests\GetDogmaAttributeRequest;
+use NicolasKion\Esi\Requests\GetDogmaAttributesRequest;
+use NicolasKion\Esi\Requests\GetDogmaEffectRequest;
+use NicolasKion\Esi\Requests\GetDogmaEffectsRequest;
 use NicolasKion\Esi\Requests\GetDogmaItemAttributesRequest;
 use NicolasKion\Esi\Requests\GetEveMailRequest;
 use NicolasKion\Esi\Requests\GetEveMailsRequest;
@@ -151,6 +157,58 @@ class Esi
     {
         $connector = new Connector;
         $request = new GetDogmaItemAttributesRequest($type_id, $item_id);
+
+        return $connector->send($request);
+    }
+
+    /**
+     * Retrieves the list of dogma attribute IDs.
+     *
+     * @return EsiResult<array<int, int>>
+     */
+    public function getDogmaAttributes(): EsiResult
+    {
+        $connector = new Connector;
+        $request = new GetDogmaAttributesRequest;
+
+        return $connector->send($request);
+    }
+
+    /**
+     * Retrieves information about a dogma attribute.
+     *
+     * @return EsiResult<DogmaAttribute>
+     */
+    public function getDogmaAttribute(int $attribute_id): EsiResult
+    {
+        $connector = new Connector;
+        $request = new GetDogmaAttributeRequest($attribute_id);
+
+        return $connector->send($request);
+    }
+
+    /**
+     * Retrieves the list of dogma effect IDs.
+     *
+     * @return EsiResult<array<int, int>>
+     */
+    public function getDogmaEffects(): EsiResult
+    {
+        $connector = new Connector;
+        $request = new GetDogmaEffectsRequest;
+
+        return $connector->send($request);
+    }
+
+    /**
+     * Retrieves information about a dogma effect.
+     *
+     * @return EsiResult<DogmaEffect>
+     */
+    public function getDogmaEffect(int $effect_id): EsiResult
+    {
+        $connector = new Connector;
+        $request = new GetDogmaEffectRequest($effect_id);
 
         return $connector->send($request);
     }

--- a/src/Requests/GetDogmaAttributeRequest.php
+++ b/src/Requests/GetDogmaAttributeRequest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\Requests;
+
+use Illuminate\Http\Client\Response;
+use NicolasKion\Esi\DTO\DogmaAttribute;
+use NicolasKion\Esi\Request;
+
+/**
+ * @extends Request<DogmaAttribute>
+ */
+class GetDogmaAttributeRequest extends Request
+{
+    public function __construct(public int $attribute_id) {}
+
+    public function resolveEndpoint(): string
+    {
+        return sprintf('/dogma/attributes/%d', $this->attribute_id);
+    }
+
+    public function createDto(Response $response, mixed $data): DogmaAttribute
+    {
+        return DogmaAttribute::hydrate($data);
+    }
+}

--- a/src/Requests/GetDogmaAttributesRequest.php
+++ b/src/Requests/GetDogmaAttributesRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\Requests;
+
+use Illuminate\Http\Client\Response;
+use NicolasKion\Esi\Request;
+use NicolasKion\Esi\Support\Data;
+
+/**
+ * @extends Request<array<int, int>>
+ */
+class GetDogmaAttributesRequest extends Request
+{
+    public function resolveEndpoint(): string
+    {
+        return '/dogma/attributes';
+    }
+
+    /**
+     * @return array<int, int>
+     */
+    public function createDto(Response $response, mixed $data): array
+    {
+        return Data::integerList($data);
+    }
+}

--- a/src/Requests/GetDogmaEffectRequest.php
+++ b/src/Requests/GetDogmaEffectRequest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\Requests;
+
+use Illuminate\Http\Client\Response;
+use NicolasKion\Esi\DTO\DogmaEffect;
+use NicolasKion\Esi\Request;
+
+/**
+ * @extends Request<DogmaEffect>
+ */
+class GetDogmaEffectRequest extends Request
+{
+    public function __construct(public int $effect_id) {}
+
+    public function resolveEndpoint(): string
+    {
+        return sprintf('/dogma/effects/%d', $this->effect_id);
+    }
+
+    public function createDto(Response $response, mixed $data): DogmaEffect
+    {
+        return DogmaEffect::hydrate($data);
+    }
+}

--- a/src/Requests/GetDogmaEffectsRequest.php
+++ b/src/Requests/GetDogmaEffectsRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\Requests;
+
+use Illuminate\Http\Client\Response;
+use NicolasKion\Esi\Request;
+use NicolasKion\Esi\Support\Data;
+
+/**
+ * @extends Request<array<int, int>>
+ */
+class GetDogmaEffectsRequest extends Request
+{
+    public function resolveEndpoint(): string
+    {
+        return '/dogma/effects';
+    }
+
+    /**
+     * @return array<int, int>
+     */
+    public function createDto(Response $response, mixed $data): array
+    {
+        return Data::integerList($data);
+    }
+}

--- a/tests/DogmaTest.php
+++ b/tests/DogmaTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Http;
+use NicolasKion\Esi\DTO\DogmaAttribute;
+use NicolasKion\Esi\DTO\DogmaEffect;
+use NicolasKion\Esi\DTO\DogmaEffectModifier;
+use NicolasKion\Esi\Esi;
+
+it('fetches the list of dogma attribute ids', function (): void {
+    Http::fake([
+        'esi.evetech.net/dogma/attributes*' => Http::response([1, 2, 3]),
+    ]);
+
+    $result = (new Esi)->getDogmaAttributes();
+
+    expect($result->wasSuccessful())->toBeTrue()
+        ->and($result->data)->toBe([1, 2, 3]);
+});
+
+it('fetches and maps a dogma attribute', function (): void {
+    Http::fake([
+        'esi.evetech.net/dogma/attributes/32*' => Http::response(esiFixture('dogma/attribute.json')),
+    ]);
+
+    $result = (new Esi)->getDogmaAttribute(32);
+
+    expect($result->wasSuccessful())->toBeTrue()
+        ->and($result->data)->toBeInstanceOf(DogmaAttribute::class)
+        ->and($result->data->attribute_id)->toBe(90000001)
+        ->and($result->data->default_value)->toBe(1.5)
+        ->and($result->data->high_is_good)->toBeTrue()
+        ->and($result->data->stackable)->toBeTrue()
+        ->and($result->data->unit_id)->toBe(90000001);
+});
+
+it('fetches the list of dogma effect ids', function (): void {
+    Http::fake([
+        'esi.evetech.net/dogma/effects*' => Http::response([10, 20]),
+    ]);
+
+    $result = (new Esi)->getDogmaEffects();
+
+    expect($result->wasSuccessful())->toBeTrue()
+        ->and($result->data)->toBe([10, 20]);
+});
+
+it('fetches and maps a dogma effect with its modifiers', function (): void {
+    Http::fake([
+        'esi.evetech.net/dogma/effects/16*' => Http::response(esiFixture('dogma/effect.json')),
+    ]);
+
+    $result = (new Esi)->getDogmaEffect(16);
+
+    expect($result->wasSuccessful())->toBeTrue()
+        ->and($result->data)->toBeInstanceOf(DogmaEffect::class)
+        ->and($result->data->effect_id)->toBe(90000001)
+        ->and($result->data->is_offensive)->toBeTrue()
+        ->and($result->data->effect_category)->toBe(90000001)
+        ->and($result->data->modifiers)->toHaveCount(1)
+        ->and($result->data->modifiers[0])->toBeInstanceOf(DogmaEffectModifier::class)
+        ->and($result->data->modifiers[0]->modified_attribute_id)->toBe(90000001)
+        ->and($result->data->modifiers[0]->domain)->toBe('string');
+});
+
+it('returns an error result when a dogma endpoint fails', function (): void {
+    Http::fake([
+        'esi.evetech.net/dogma/attributes/32*' => Http::response('error', 500),
+    ]);
+
+    $result = (new Esi)->getDogmaAttribute(32);
+
+    expect($result->failed())->toBeTrue()
+        ->and($result->error?->code)->toBe(500);
+});

--- a/tests/Fixtures/dogma/attribute.json
+++ b/tests/Fixtures/dogma/attribute.json
@@ -1,0 +1,12 @@
+{
+    "attribute_id": 90000001,
+    "default_value": 1.5,
+    "description": "string",
+    "display_name": "string",
+    "high_is_good": true,
+    "icon_id": 90000001,
+    "name": "string",
+    "published": true,
+    "stackable": true,
+    "unit_id": 90000001
+}

--- a/tests/Fixtures/dogma/effect.json
+++ b/tests/Fixtures/dogma/effect.json
@@ -1,0 +1,32 @@
+{
+    "description": "string",
+    "disallow_auto_repeat": true,
+    "discharge_attribute_id": 90000001,
+    "display_name": "string",
+    "duration_attribute_id": 90000001,
+    "effect_category": 90000001,
+    "effect_id": 90000001,
+    "electronic_chance": true,
+    "falloff_attribute_id": 90000001,
+    "icon_id": 90000001,
+    "is_assistance": true,
+    "is_offensive": true,
+    "is_warp_safe": true,
+    "modifiers": [
+        {
+            "domain": "string",
+            "effect_id": 90000001,
+            "func": "string",
+            "modified_attribute_id": 90000001,
+            "modifying_attribute_id": 90000001,
+            "operator": 90000001
+        }
+    ],
+    "name": "string",
+    "post_expression": 90000001,
+    "pre_expression": 90000001,
+    "published": true,
+    "range_attribute_id": 90000001,
+    "range_chance": true,
+    "tracking_speed_attribute_id": 90000001
+}


### PR DESCRIPTION
First domain in the endpoint-coverage effort. Adds the 4 remaining public Dogma endpoints (attribute/effect lists + detail) with DTOs, requests, facade methods, fixtures and tests. PHPStan level 9 clean, full suite green (101 tests).