### PR TITLE
feat: add alliance corporations and icons endpoints

### DIFF
--- a/src/DTO/AllianceIcons.php
+++ b/src/DTO/AllianceIcons.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\DTO;
+
+use NicolasKion\Esi\Support\Data;
+
+readonly class AllianceIcons extends Dto
+{
+    public function __construct(
+        public ?string $px64x64,
+        public ?string $px128x128,
+    ) {}
+
+    public static function fromData(Data $data): self
+    {
+        return new self(
+            px64x64: $data->string('px64x64'),
+            px128x128: $data->string('px128x128'),
+        );
+    }
+}

--- a/src/Esi.php
+++ b/src/Esi.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 namespace NicolasKion\Esi;
 
 use NicolasKion\Esi\DTO\Alliance;
+use NicolasKion\Esi\DTO\AllianceIcons;
 use NicolasKion\Esi\DTO\Asset;
 use NicolasKion\Esi\DTO\AssetName;
 use NicolasKion\Esi\DTO\CharacterAffiliation;
@@ -45,6 +46,8 @@ use NicolasKion\Esi\Requests\EditCharacterContactsRequest;
 use NicolasKion\Esi\Requests\GetAffiliationsRequest;
 use NicolasKion\Esi\Requests\GetAllianceContactLabelsRequest;
 use NicolasKion\Esi\Requests\GetAllianceContactsRequest;
+use NicolasKion\Esi\Requests\GetAllianceCorporationsRequest;
+use NicolasKion\Esi\Requests\GetAllianceIconsRequest;
 use NicolasKion\Esi\Requests\GetAllianceRequest;
 use NicolasKion\Esi\Requests\GetAlliancesRequest;
 use NicolasKion\Esi\Requests\GetAssetNamesRequest;
@@ -560,6 +563,32 @@ class Esi
         $request = new GetAlliancesRequest;
 
         return $connector->sendPaginated($request);
+    }
+
+    /**
+     * Retrieves the corporation IDs of the members of an alliance.
+     *
+     * @return EsiResult<array<int, int>>
+     */
+    public function getAllianceCorporations(int $alliance_id): EsiResult
+    {
+        $connector = new Connector;
+        $request = new GetAllianceCorporationsRequest($alliance_id);
+
+        return $connector->send($request);
+    }
+
+    /**
+     * Retrieves the icon URLs for an alliance.
+     *
+     * @return EsiResult<AllianceIcons>
+     */
+    public function getAllianceIcons(int $alliance_id): EsiResult
+    {
+        $connector = new Connector;
+        $request = new GetAllianceIconsRequest($alliance_id);
+
+        return $connector->send($request);
     }
 
     /**

--- a/src/Requests/GetAllianceCorporationsRequest.php
+++ b/src/Requests/GetAllianceCorporationsRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\Requests;
+
+use Illuminate\Http\Client\Response;
+use NicolasKion\Esi\Request;
+use NicolasKion\Esi\Support\Data;
+
+/**
+ * @extends Request<array<int, int>>
+ */
+class GetAllianceCorporationsRequest extends Request
+{
+    public function __construct(public int $alliance_id) {}
+
+    public function resolveEndpoint(): string
+    {
+        return sprintf('/alliances/%d/corporations', $this->alliance_id);
+    }
+
+    /**
+     * @return array<int, int>
+     */
+    public function createDto(Response $response, mixed $data): array
+    {
+        return Data::integerList($data);
+    }
+}

--- a/src/Requests/GetAllianceIconsRequest.php
+++ b/src/Requests/GetAllianceIconsRequest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\Requests;
+
+use Illuminate\Http\Client\Response;
+use NicolasKion\Esi\DTO\AllianceIcons;
+use NicolasKion\Esi\Request;
+
+/**
+ * @extends Request<AllianceIcons>
+ */
+class GetAllianceIconsRequest extends Request
+{
+    public function __construct(public int $alliance_id) {}
+
+    public function resolveEndpoint(): string
+    {
+        return sprintf('/alliances/%d/icons', $this->alliance_id);
+    }
+
+    public function createDto(Response $response, mixed $data): AllianceIcons
+    {
+        return AllianceIcons::hydrate($data);
+    }
+}

--- a/tests/AllianceTest.php
+++ b/tests/AllianceTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Illuminate\Support\Facades\Http;
 use NicolasKion\Esi\DTO\Alliance;
+use NicolasKion\Esi\DTO\AllianceIcons;
 use NicolasKion\Esi\Esi;
 
 it('fetches and maps an alliance', function (): void {
@@ -49,4 +50,28 @@ it('returns an error result when the alliance endpoint fails', function (): void
 
     expect($result->failed())->toBeTrue()
         ->and($result->error?->code)->toBe(500);
+});
+
+it('fetches the member corporation ids of an alliance', function (): void {
+    Http::fake([
+        'esi.evetech.net/alliances/99000001/corporations*' => Http::response([98000001, 98000002]),
+    ]);
+
+    $result = (new Esi)->getAllianceCorporations(99000001);
+
+    expect($result->wasSuccessful())->toBeTrue()
+        ->and($result->data)->toBe([98000001, 98000002]);
+});
+
+it('fetches and maps alliance icons', function (): void {
+    Http::fake([
+        'esi.evetech.net/alliances/99000001/icons*' => Http::response(esiFixture('alliances/icons.json')),
+    ]);
+
+    $result = (new Esi)->getAllianceIcons(99000001);
+
+    expect($result->wasSuccessful())->toBeTrue()
+        ->and($result->data)->toBeInstanceOf(AllianceIcons::class)
+        ->and($result->data->px64x64)->toBe('string')
+        ->and($result->data->px128x128)->toBe('string');
 });

--- a/tests/Fixtures/alliances/icons.json
+++ b/tests/Fixtures/alliances/icons.json
@@ -1,0 +1,4 @@
+{
+    "px128x128": "string",
+    "px64x64": "string"
+}


### PR DESCRIPTION
Completes the Alliance domain: member corporation IDs + icon URLs. DTO + requests + facade methods + fixture + tests. PHPStan level 9 clean, 100% coverage.