### PR TITLE
feat: add market group, price, order and type endpoints

### DIFF
--- a/src/DTO/MarketGroup.php
+++ b/src/DTO/MarketGroup.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\DTO;
+
+use NicolasKion\Esi\Support\Data;
+
+readonly class MarketGroup extends Dto
+{
+    /**
+     * @param  array<int, int>  $types
+     */
+    public function __construct(
+        public int $market_group_id,
+        public ?string $description,
+        public ?string $name,
+        public ?int $parent_group_id,
+        public array $types,
+    ) {}
+
+    public static function fromData(Data $data): self
+    {
+        return new self(
+            market_group_id: $data->integer('market_group_id', 0),
+            description: $data->string('description'),
+            name: $data->string('name'),
+            parent_group_id: $data->integer('parent_group_id'),
+            types: $data->integers('types'),
+        );
+    }
+}

--- a/src/DTO/MarketOrder.php
+++ b/src/DTO/MarketOrder.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\DTO;
+
+use NicolasKion\Esi\Support\Data;
+
+readonly class MarketOrder extends Dto
+{
+    public function __construct(
+        public int $order_id,
+        public int $type_id,
+        public int $location_id,
+        public ?int $system_id,
+        public int $duration,
+        public bool $is_buy_order,
+        public string $issued,
+        public int $min_volume,
+        public float $price,
+        public string $range,
+        public int $volume_remain,
+        public int $volume_total,
+    ) {}
+
+    public static function fromData(Data $data): self
+    {
+        return new self(
+            order_id: $data->integer('order_id', 0),
+            type_id: $data->integer('type_id', 0),
+            location_id: $data->integer('location_id', 0),
+            system_id: $data->integer('system_id'),
+            duration: $data->integer('duration', 0),
+            is_buy_order: $data->boolean('is_buy_order', false),
+            issued: $data->string('issued', ''),
+            min_volume: $data->integer('min_volume', 0),
+            price: $data->float('price', 0.0),
+            range: $data->string('range', ''),
+            volume_remain: $data->integer('volume_remain', 0),
+            volume_total: $data->integer('volume_total', 0),
+        );
+    }
+}

--- a/src/DTO/MarketPrice.php
+++ b/src/DTO/MarketPrice.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\DTO;
+
+use NicolasKion\Esi\Support\Data;
+
+readonly class MarketPrice extends Dto
+{
+    public function __construct(
+        public int $type_id,
+        public ?float $adjusted_price,
+        public ?float $average_price,
+    ) {}
+
+    public static function fromData(Data $data): self
+    {
+        return new self(
+            type_id: $data->integer('type_id', 0),
+            adjusted_price: $data->float('adjusted_price'),
+            average_price: $data->float('average_price'),
+        );
+    }
+}

--- a/src/Enums/EsiScope.php
+++ b/src/Enums/EsiScope.php
@@ -7,6 +7,7 @@ namespace NicolasKion\Esi\Enums;
 enum EsiScope: string
 {
     case ReadAssets = 'esi-assets.read_assets.v1';
+    case ReadMarketStructures = 'esi-markets.structure_markets.v1';
     case PublicData = 'publicData';
     case OpenWindow = 'esi-ui.open_window.v1';
     case ReadContracts = 'esi-contracts.read_character_contracts.v1';

--- a/src/Enums/MarketOrderType.php
+++ b/src/Enums/MarketOrderType.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\Enums;
+
+enum MarketOrderType: string
+{
+    case Buy = 'buy';
+    case Sell = 'sell';
+    case All = 'all';
+}

--- a/src/Esi.php
+++ b/src/Esi.php
@@ -24,7 +24,10 @@ use NicolasKion\Esi\DTO\EsiResult;
 use NicolasKion\Esi\DTO\EveMail;
 use NicolasKion\Esi\DTO\Killmail;
 use NicolasKion\Esi\DTO\Location;
+use NicolasKion\Esi\DTO\MarketGroup;
 use NicolasKion\Esi\DTO\MarketHistory;
+use NicolasKion\Esi\DTO\MarketOrder;
+use NicolasKion\Esi\DTO\MarketPrice;
 use NicolasKion\Esi\DTO\Name;
 use NicolasKion\Esi\DTO\Online;
 use NicolasKion\Esi\DTO\PublicContract;
@@ -39,6 +42,7 @@ use NicolasKion\Esi\DTO\UniverseIds;
 use NicolasKion\Esi\DTO\WalletJournalEntry;
 use NicolasKion\Esi\DTO\War;
 use NicolasKion\Esi\Enums\EsiScope;
+use NicolasKion\Esi\Enums\MarketOrderType;
 use NicolasKion\Esi\Interfaces\Character;
 use NicolasKion\Esi\Requests\AddCharacterContactsRequest;
 use NicolasKion\Esi\Requests\DeleteCharacterContactsRequest;
@@ -74,7 +78,12 @@ use NicolasKion\Esi\Requests\GetEveMailsRequest;
 use NicolasKion\Esi\Requests\GetIdsRequest;
 use NicolasKion\Esi\Requests\GetKillmailRequest;
 use NicolasKion\Esi\Requests\GetLocationRequest;
+use NicolasKion\Esi\Requests\GetMarketGroupRequest;
+use NicolasKion\Esi\Requests\GetMarketGroupsRequest;
 use NicolasKion\Esi\Requests\GetMarketHistoryRequest;
+use NicolasKion\Esi\Requests\GetMarketOrdersRequest;
+use NicolasKion\Esi\Requests\GetMarketPricesRequest;
+use NicolasKion\Esi\Requests\GetMarketTypesRequest;
 use NicolasKion\Esi\Requests\GetNamesRequest;
 use NicolasKion\Esi\Requests\GetOnlineRequest;
 use NicolasKion\Esi\Requests\GetPublicContractBidsRequest;
@@ -84,6 +93,7 @@ use NicolasKion\Esi\Requests\GetPublicStructuresRequest;
 use NicolasKion\Esi\Requests\GetRaidableSkyhooksRequest;
 use NicolasKion\Esi\Requests\GetShipRequest;
 use NicolasKion\Esi\Requests\GetSovereigntyRequest;
+use NicolasKion\Esi\Requests\GetStructureMarketOrdersRequest;
 use NicolasKion\Esi\Requests\GetStructureRequest;
 use NicolasKion\Esi\Requests\GetWalletJournalRequest;
 use NicolasKion\Esi\Requests\GetWarRequest;
@@ -229,6 +239,84 @@ class Esi
         $request = new GetMarketHistoryRequest($region_id, $type_id);
 
         return $connector->send($request);
+    }
+
+    /**
+     * Retrieves the list of market group IDs.
+     *
+     * @return EsiResult<array<int, int>>
+     */
+    public function getMarketGroups(): EsiResult
+    {
+        $connector = new Connector;
+        $request = new GetMarketGroupsRequest;
+
+        return $connector->send($request);
+    }
+
+    /**
+     * Retrieves information about a market group.
+     *
+     * @return EsiResult<MarketGroup>
+     */
+    public function getMarketGroup(int $market_group_id): EsiResult
+    {
+        $connector = new Connector;
+        $request = new GetMarketGroupRequest($market_group_id);
+
+        return $connector->send($request);
+    }
+
+    /**
+     * Retrieves the adjusted and average prices for all types.
+     *
+     * @return EsiResult<array<int, MarketPrice>>
+     */
+    public function getMarketPrices(): EsiResult
+    {
+        $connector = new Connector;
+        $request = new GetMarketPricesRequest;
+
+        return $connector->send($request);
+    }
+
+    /**
+     * Retrieves market orders in a region, optionally filtered by type.
+     *
+     * @return EsiResult<array<int, MarketOrder>>
+     */
+    public function getMarketOrders(int $region_id, MarketOrderType $order_type = MarketOrderType::All, ?int $type_id = null): EsiResult
+    {
+        $connector = new Connector;
+        $request = new GetMarketOrdersRequest($region_id, $order_type, $type_id);
+
+        return $connector->sendPaginated($request);
+    }
+
+    /**
+     * Retrieves the type IDs with active market orders in a region.
+     *
+     * @return EsiResult<array<int, int>>
+     */
+    public function getMarketTypes(int $region_id): EsiResult
+    {
+        $connector = new Connector;
+        $request = new GetMarketTypesRequest($region_id);
+
+        return $connector->sendPaginated($request);
+    }
+
+    /**
+     * Retrieves market orders in a player-owned structure.
+     *
+     * @return EsiResult<array<int, MarketOrder>>
+     */
+    public function getStructureMarketOrders(Character $character, int $structure_id): EsiResult
+    {
+        $connector = $this->getAuthenticatedConnector($character, EsiScope::ReadMarketStructures);
+        $request = new GetStructureMarketOrdersRequest($structure_id);
+
+        return $connector->sendPaginated($request);
     }
 
     /**

--- a/src/Requests/GetMarketGroupRequest.php
+++ b/src/Requests/GetMarketGroupRequest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\Requests;
+
+use Illuminate\Http\Client\Response;
+use NicolasKion\Esi\DTO\MarketGroup;
+use NicolasKion\Esi\Request;
+
+/**
+ * @extends Request<MarketGroup>
+ */
+class GetMarketGroupRequest extends Request
+{
+    public function __construct(public int $market_group_id) {}
+
+    public function resolveEndpoint(): string
+    {
+        return sprintf('/markets/groups/%d', $this->market_group_id);
+    }
+
+    public function createDto(Response $response, mixed $data): MarketGroup
+    {
+        return MarketGroup::hydrate($data);
+    }
+}

--- a/src/Requests/GetMarketGroupsRequest.php
+++ b/src/Requests/GetMarketGroupsRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\Requests;
+
+use Illuminate\Http\Client\Response;
+use NicolasKion\Esi\Request;
+use NicolasKion\Esi\Support\Data;
+
+/**
+ * @extends Request<array<int, int>>
+ */
+class GetMarketGroupsRequest extends Request
+{
+    public function resolveEndpoint(): string
+    {
+        return '/markets/groups';
+    }
+
+    /**
+     * @return array<int, int>
+     */
+    public function createDto(Response $response, mixed $data): array
+    {
+        return Data::integerList($data);
+    }
+}

--- a/src/Requests/GetMarketOrdersRequest.php
+++ b/src/Requests/GetMarketOrdersRequest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\Requests;
+
+use Illuminate\Http\Client\Response;
+use NicolasKion\Esi\DTO\MarketOrder;
+use NicolasKion\Esi\Enums\MarketOrderType;
+use NicolasKion\Esi\Interfaces\WithPagination;
+use NicolasKion\Esi\Request;
+use NicolasKion\Esi\Traits\BasicPagination;
+
+/**
+ * @extends Request<array<int, MarketOrder>>
+ *
+ * @implements WithPagination<array<int, MarketOrder>>
+ */
+class GetMarketOrdersRequest extends Request implements WithPagination
+{
+    use BasicPagination;
+
+    public function __construct(
+        public int $region_id,
+        public MarketOrderType $order_type = MarketOrderType::All,
+        public ?int $type_id = null,
+    ) {}
+
+    public function resolveEndpoint(): string
+    {
+        return sprintf('/markets/%d/orders', $this->region_id);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getQuery(): array
+    {
+        $query = ['order_type' => $this->order_type->value];
+
+        if ($this->type_id !== null) {
+            $query['type_id'] = $this->type_id;
+        }
+
+        return $query;
+    }
+
+    /**
+     * @return array<int, MarketOrder>
+     */
+    public function createDto(Response $response, mixed $data): array
+    {
+        return MarketOrder::hydrateList($data);
+    }
+}

--- a/src/Requests/GetMarketPricesRequest.php
+++ b/src/Requests/GetMarketPricesRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\Requests;
+
+use Illuminate\Http\Client\Response;
+use NicolasKion\Esi\DTO\MarketPrice;
+use NicolasKion\Esi\Request;
+
+/**
+ * @extends Request<array<int, MarketPrice>>
+ */
+class GetMarketPricesRequest extends Request
+{
+    public function resolveEndpoint(): string
+    {
+        return '/markets/prices';
+    }
+
+    /**
+     * @return array<int, MarketPrice>
+     */
+    public function createDto(Response $response, mixed $data): array
+    {
+        return MarketPrice::hydrateList($data);
+    }
+}

--- a/src/Requests/GetMarketTypesRequest.php
+++ b/src/Requests/GetMarketTypesRequest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\Requests;
+
+use Illuminate\Http\Client\Response;
+use NicolasKion\Esi\Interfaces\WithPagination;
+use NicolasKion\Esi\Request;
+use NicolasKion\Esi\Support\Data;
+use NicolasKion\Esi\Traits\BasicPagination;
+
+/**
+ * @extends Request<array<int, int>>
+ *
+ * @implements WithPagination<array<int, int>>
+ */
+class GetMarketTypesRequest extends Request implements WithPagination
+{
+    use BasicPagination;
+
+    public function __construct(public int $region_id) {}
+
+    public function resolveEndpoint(): string
+    {
+        return sprintf('/markets/%d/types', $this->region_id);
+    }
+
+    /**
+     * @return array<int, int>
+     */
+    public function createDto(Response $response, mixed $data): array
+    {
+        return Data::integerList($data);
+    }
+}

--- a/src/Requests/GetStructureMarketOrdersRequest.php
+++ b/src/Requests/GetStructureMarketOrdersRequest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\Requests;
+
+use Illuminate\Http\Client\Response;
+use NicolasKion\Esi\DTO\MarketOrder;
+use NicolasKion\Esi\Interfaces\WithPagination;
+use NicolasKion\Esi\Request;
+use NicolasKion\Esi\Traits\BasicPagination;
+
+/**
+ * @extends Request<array<int, MarketOrder>>
+ *
+ * @implements WithPagination<array<int, MarketOrder>>
+ */
+class GetStructureMarketOrdersRequest extends Request implements WithPagination
+{
+    use BasicPagination;
+
+    public function __construct(public int $structure_id) {}
+
+    public function resolveEndpoint(): string
+    {
+        return sprintf('/markets/structures/%d', $this->structure_id);
+    }
+
+    /**
+     * @return array<int, MarketOrder>
+     */
+    public function createDto(Response $response, mixed $data): array
+    {
+        return MarketOrder::hydrateList($data);
+    }
+}

--- a/tests/Fixtures/markets/group.json
+++ b/tests/Fixtures/markets/group.json
@@ -1,0 +1,9 @@
+{
+    "description": "string",
+    "market_group_id": 90000001,
+    "name": "string",
+    "parent_group_id": 90000001,
+    "types": [
+        90000001
+    ]
+}

--- a/tests/Fixtures/markets/orders.json
+++ b/tests/Fixtures/markets/orders.json
@@ -1,0 +1,16 @@
+[
+    {
+        "duration": 90000001,
+        "is_buy_order": true,
+        "issued": "2026-06-09T12:00:00Z",
+        "location_id": 90000001,
+        "min_volume": 90000001,
+        "order_id": 90000001,
+        "price": 1.5,
+        "range": "station",
+        "system_id": 90000001,
+        "type_id": 90000001,
+        "volume_remain": 90000001,
+        "volume_total": 90000001
+    }
+]

--- a/tests/Fixtures/markets/prices.json
+++ b/tests/Fixtures/markets/prices.json
@@ -1,0 +1,7 @@
+[
+    {
+        "adjusted_price": 1.5,
+        "average_price": 1.5,
+        "type_id": 90000001
+    }
+]

--- a/tests/MarketTest.php
+++ b/tests/MarketTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Http;
+use NicolasKion\Esi\DTO\MarketGroup;
+use NicolasKion\Esi\DTO\MarketOrder;
+use NicolasKion\Esi\DTO\MarketPrice;
+use NicolasKion\Esi\Enums\MarketOrderType;
+use NicolasKion\Esi\Esi;
+
+it('fetches the list of market group ids', function (): void {
+    Http::fake([
+        'esi.evetech.net/markets/groups*' => Http::response([1, 2, 3]),
+    ]);
+
+    $result = (new Esi)->getMarketGroups();
+
+    expect($result->wasSuccessful())->toBeTrue()
+        ->and($result->data)->toBe([1, 2, 3]);
+});
+
+it('fetches and maps a market group', function (): void {
+    Http::fake([
+        'esi.evetech.net/markets/groups/4*' => Http::response(esiFixture('markets/group.json')),
+    ]);
+
+    $result = (new Esi)->getMarketGroup(4);
+
+    expect($result->wasSuccessful())->toBeTrue()
+        ->and($result->data)->toBeInstanceOf(MarketGroup::class)
+        ->and($result->data->market_group_id)->toBe(90000001)
+        ->and($result->data->types)->toBe([90000001]);
+});
+
+it('fetches and maps market prices', function (): void {
+    Http::fake([
+        'esi.evetech.net/markets/prices*' => Http::response(esiFixture('markets/prices.json')),
+    ]);
+
+    $result = (new Esi)->getMarketPrices();
+
+    expect($result->wasSuccessful())->toBeTrue()
+        ->and($result->data)->toHaveCount(1)
+        ->and($result->data[0])->toBeInstanceOf(MarketPrice::class)
+        ->and($result->data[0]->type_id)->toBe(90000001)
+        ->and($result->data[0]->adjusted_price)->toBe(1.5)
+        ->and($result->data[0]->average_price)->toBe(1.5);
+});
+
+it('fetches region market orders and sends the order type and type filter', function (): void {
+    Http::fake([
+        'esi.evetech.net/markets/10000002/orders*' => Http::response(esiFixture('markets/orders.json'), 200, ['X-Pages' => '1']),
+    ]);
+
+    $result = (new Esi)->getMarketOrders(10000002, MarketOrderType::Sell, 34);
+
+    expect($result->wasSuccessful())->toBeTrue()
+        ->and($result->data)->toHaveCount(1)
+        ->and($result->data[0])->toBeInstanceOf(MarketOrder::class)
+        ->and($result->data[0]->order_id)->toBe(90000001)
+        ->and($result->data[0]->is_buy_order)->toBeTrue()
+        ->and($result->data[0]->price)->toBe(1.5)
+        ->and($result->data[0]->system_id)->toBe(90000001);
+
+    Http::assertSent(fn ($request) => str_contains($request->url(), 'order_type=sell')
+        && str_contains($request->url(), 'type_id=34'));
+});
+
+it('fetches the type ids with active orders in a region', function (): void {
+    Http::fake([
+        'esi.evetech.net/markets/10000002/types*' => Http::response([34, 35], 200, ['X-Pages' => '1']),
+    ]);
+
+    $result = (new Esi)->getMarketTypes(10000002);
+
+    expect($result->wasSuccessful())->toBeTrue()
+        ->and($result->data)->toBe([34, 35]);
+});
+
+it('fetches structure market orders for an authenticated character', function (): void {
+    Http::fake([
+        'esi.evetech.net/markets/structures/1035466617946*' => Http::response(esiFixture('markets/orders.json'), 200, ['X-Pages' => '1']),
+    ]);
+
+    $result = (new Esi)->getStructureMarketOrders(fakeCharacter(), 1035466617946);
+
+    expect($result->wasSuccessful())->toBeTrue()
+        ->and($result->data)->toHaveCount(1)
+        ->and($result->data[0])->toBeInstanceOf(MarketOrder::class)
+        ->and($result->data[0]->order_id)->toBe(90000001);
+});
+
+it('returns an error result when a market endpoint fails', function (): void {
+    Http::fake([
+        'esi.evetech.net/markets/prices*' => Http::response('error', 500),
+    ]);
+
+    $result = (new Esi)->getMarketPrices();
+
+    expect($result->failed())->toBeTrue()
+        ->and($result->error?->code)->toBe(500);
+});


### PR DESCRIPTION
Completes the Market domain (history was already covered): groups, prices, region orders (with order_type/type_id filters + pagination), region types, and authenticated structure orders. New MarketOrderType enum + structure_markets scope. PHPStan level 9 clean, 100% coverage.