### PR TITLE
feat: add remaining corporation endpoints

### DIFF
--- a/src/DTO/AllianceHistory.php
+++ b/src/DTO/AllianceHistory.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\DTO;
+
+use NicolasKion\Esi\Support\Data;
+
+readonly class AllianceHistory extends Dto
+{
+    public function __construct(
+        public ?int $alliance_id,
+        public ?bool $is_deleted,
+        public int $record_id,
+        public string $start_date,
+    ) {}
+
+    public static function fromData(Data $data): self
+    {
+        return new self(
+            alliance_id: $data->integer('alliance_id'),
+            is_deleted: $data->boolean('is_deleted'),
+            record_id: $data->integer('record_id', 0),
+            start_date: $data->string('start_date', ''),
+        );
+    }
+}

--- a/src/DTO/Blueprint.php
+++ b/src/DTO/Blueprint.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\DTO;
+
+use NicolasKion\Esi\Support\Data;
+
+readonly class Blueprint extends Dto
+{
+    public function __construct(
+        public int $item_id,
+        public string $location_flag,
+        public int $location_id,
+        public int $material_efficiency,
+        public int $quantity,
+        public int $runs,
+        public int $time_efficiency,
+        public int $type_id,
+    ) {}
+
+    public static function fromData(Data $data): self
+    {
+        return new self(
+            item_id: $data->integer('item_id', 0),
+            location_flag: $data->string('location_flag', ''),
+            location_id: $data->integer('location_id', 0),
+            material_efficiency: $data->integer('material_efficiency', 0),
+            quantity: $data->integer('quantity', 0),
+            runs: $data->integer('runs', 0),
+            time_efficiency: $data->integer('time_efficiency', 0),
+            type_id: $data->integer('type_id', 0),
+        );
+    }
+}

--- a/src/DTO/ContainerLog.php
+++ b/src/DTO/ContainerLog.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\DTO;
+
+use NicolasKion\Esi\Support\Data;
+
+readonly class ContainerLog extends Dto
+{
+    public function __construct(
+        public string $action,
+        public int $character_id,
+        public int $container_id,
+        public int $container_type_id,
+        public string $location_flag,
+        public int $location_id,
+        public string $logged_at,
+        public ?int $new_config_bitmask,
+        public ?int $old_config_bitmask,
+        public ?string $password_type,
+        public ?int $quantity,
+        public ?int $type_id,
+    ) {}
+
+    public static function fromData(Data $data): self
+    {
+        return new self(
+            action: $data->string('action', ''),
+            character_id: $data->integer('character_id', 0),
+            container_id: $data->integer('container_id', 0),
+            container_type_id: $data->integer('container_type_id', 0),
+            location_flag: $data->string('location_flag', ''),
+            location_id: $data->integer('location_id', 0),
+            logged_at: $data->string('logged_at', ''),
+            new_config_bitmask: $data->integer('new_config_bitmask'),
+            old_config_bitmask: $data->integer('old_config_bitmask'),
+            password_type: $data->string('password_type'),
+            quantity: $data->integer('quantity'),
+            type_id: $data->integer('type_id'),
+        );
+    }
+}

--- a/src/DTO/CorporationIcons.php
+++ b/src/DTO/CorporationIcons.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\DTO;
+
+use NicolasKion\Esi\Support\Data;
+
+readonly class CorporationIcons extends Dto
+{
+    public function __construct(
+        public ?string $px128x128,
+        public ?string $px256x256,
+        public ?string $px64x64,
+    ) {}
+
+    public static function fromData(Data $data): self
+    {
+        return new self(
+            px128x128: $data->string('px128x128'),
+            px256x256: $data->string('px256x256'),
+            px64x64: $data->string('px64x64'),
+        );
+    }
+}

--- a/src/DTO/CorporationMedal.php
+++ b/src/DTO/CorporationMedal.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\DTO;
+
+use NicolasKion\Esi\Support\Data;
+
+readonly class CorporationMedal extends Dto
+{
+    public function __construct(
+        public string $created_at,
+        public int $creator_id,
+        public string $description,
+        public int $medal_id,
+        public string $title,
+    ) {}
+
+    public static function fromData(Data $data): self
+    {
+        return new self(
+            created_at: $data->string('created_at', ''),
+            creator_id: $data->integer('creator_id', 0),
+            description: $data->string('description', ''),
+            medal_id: $data->integer('medal_id', 0),
+            title: $data->string('title', ''),
+        );
+    }
+}

--- a/src/DTO/CorporationRoles.php
+++ b/src/DTO/CorporationRoles.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\DTO;
+
+use NicolasKion\Esi\Support\Data;
+
+readonly class CorporationRoles extends Dto
+{
+    /**
+     * @param  array<int, string>  $grantable_roles
+     * @param  array<int, string>  $grantable_roles_at_base
+     * @param  array<int, string>  $grantable_roles_at_hq
+     * @param  array<int, string>  $grantable_roles_at_other
+     * @param  array<int, string>  $roles
+     * @param  array<int, string>  $roles_at_base
+     * @param  array<int, string>  $roles_at_hq
+     * @param  array<int, string>  $roles_at_other
+     */
+    public function __construct(
+        public int $character_id,
+        public array $grantable_roles,
+        public array $grantable_roles_at_base,
+        public array $grantable_roles_at_hq,
+        public array $grantable_roles_at_other,
+        public array $roles,
+        public array $roles_at_base,
+        public array $roles_at_hq,
+        public array $roles_at_other,
+    ) {}
+
+    public static function fromData(Data $data): self
+    {
+        return new self(
+            character_id: $data->integer('character_id', 0),
+            grantable_roles: self::stringList($data->raw('grantable_roles')),
+            grantable_roles_at_base: self::stringList($data->raw('grantable_roles_at_base')),
+            grantable_roles_at_hq: self::stringList($data->raw('grantable_roles_at_hq')),
+            grantable_roles_at_other: self::stringList($data->raw('grantable_roles_at_other')),
+            roles: self::stringList($data->raw('roles')),
+            roles_at_base: self::stringList($data->raw('roles_at_base')),
+            roles_at_hq: self::stringList($data->raw('roles_at_hq')),
+            roles_at_other: self::stringList($data->raw('roles_at_other')),
+        );
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private static function stringList(mixed $raw): array
+    {
+        if (! is_array($raw)) {
+            return [];
+        }
+
+        return array_values(array_map(
+            static fn (mixed $value): string => is_string($value) ? $value : '',
+            $raw,
+        ));
+    }
+}

--- a/src/DTO/CorporationTitle.php
+++ b/src/DTO/CorporationTitle.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\DTO;
+
+use NicolasKion\Esi\Support\Data;
+
+readonly class CorporationTitle extends Dto
+{
+    /**
+     * @param  array<int, string>  $grantable_roles
+     * @param  array<int, string>  $grantable_roles_at_base
+     * @param  array<int, string>  $grantable_roles_at_hq
+     * @param  array<int, string>  $grantable_roles_at_other
+     * @param  array<int, string>  $roles
+     * @param  array<int, string>  $roles_at_base
+     * @param  array<int, string>  $roles_at_hq
+     * @param  array<int, string>  $roles_at_other
+     */
+    public function __construct(
+        public array $grantable_roles,
+        public array $grantable_roles_at_base,
+        public array $grantable_roles_at_hq,
+        public array $grantable_roles_at_other,
+        public ?string $name,
+        public array $roles,
+        public array $roles_at_base,
+        public array $roles_at_hq,
+        public array $roles_at_other,
+        public ?int $title_id,
+    ) {}
+
+    public static function fromData(Data $data): self
+    {
+        return new self(
+            grantable_roles: self::stringList($data->raw('grantable_roles')),
+            grantable_roles_at_base: self::stringList($data->raw('grantable_roles_at_base')),
+            grantable_roles_at_hq: self::stringList($data->raw('grantable_roles_at_hq')),
+            grantable_roles_at_other: self::stringList($data->raw('grantable_roles_at_other')),
+            name: $data->string('name'),
+            roles: self::stringList($data->raw('roles')),
+            roles_at_base: self::stringList($data->raw('roles_at_base')),
+            roles_at_hq: self::stringList($data->raw('roles_at_hq')),
+            roles_at_other: self::stringList($data->raw('roles_at_other')),
+            title_id: $data->integer('title_id'),
+        );
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private static function stringList(mixed $raw): array
+    {
+        if (! is_array($raw)) {
+            return [];
+        }
+
+        return array_values(array_map(
+            static fn (mixed $value): string => is_string($value) ? $value : '',
+            $raw,
+        ));
+    }
+}

--- a/src/DTO/Facility.php
+++ b/src/DTO/Facility.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\DTO;
+
+use NicolasKion\Esi\Support\Data;
+
+readonly class Facility extends Dto
+{
+    public function __construct(
+        public int $facility_id,
+        public int $system_id,
+        public int $type_id,
+    ) {}
+
+    public static function fromData(Data $data): self
+    {
+        return new self(
+            facility_id: $data->integer('facility_id', 0),
+            system_id: $data->integer('system_id', 0),
+            type_id: $data->integer('type_id', 0),
+        );
+    }
+}

--- a/src/DTO/IssuedMedal.php
+++ b/src/DTO/IssuedMedal.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\DTO;
+
+use NicolasKion\Esi\Support\Data;
+
+readonly class IssuedMedal extends Dto
+{
+    public function __construct(
+        public int $character_id,
+        public string $issued_at,
+        public int $issuer_id,
+        public int $medal_id,
+        public string $reason,
+        public string $status,
+    ) {}
+
+    public static function fromData(Data $data): self
+    {
+        return new self(
+            character_id: $data->integer('character_id', 0),
+            issued_at: $data->string('issued_at', ''),
+            issuer_id: $data->integer('issuer_id', 0),
+            medal_id: $data->integer('medal_id', 0),
+            reason: $data->string('reason', ''),
+            status: $data->string('status', ''),
+        );
+    }
+}

--- a/src/DTO/MemberTitles.php
+++ b/src/DTO/MemberTitles.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\DTO;
+
+use NicolasKion\Esi\Support\Data;
+
+readonly class MemberTitles extends Dto
+{
+    /**
+     * @param  array<int, int>  $titles
+     */
+    public function __construct(
+        public int $character_id,
+        public array $titles,
+    ) {}
+
+    public static function fromData(Data $data): self
+    {
+        return new self(
+            character_id: $data->integer('character_id', 0),
+            titles: $data->integers('titles'),
+        );
+    }
+}

--- a/src/DTO/MemberTracking.php
+++ b/src/DTO/MemberTracking.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\DTO;
+
+use NicolasKion\Esi\Support\Data;
+
+readonly class MemberTracking extends Dto
+{
+    public function __construct(
+        public ?int $base_id,
+        public int $character_id,
+        public ?int $location_id,
+        public ?string $logoff_date,
+        public ?string $logon_date,
+        public ?int $ship_type_id,
+        public ?string $start_date,
+    ) {}
+
+    public static function fromData(Data $data): self
+    {
+        return new self(
+            base_id: $data->integer('base_id'),
+            character_id: $data->integer('character_id', 0),
+            location_id: $data->integer('location_id'),
+            logoff_date: $data->string('logoff_date'),
+            logon_date: $data->string('logon_date'),
+            ship_type_id: $data->integer('ship_type_id'),
+            start_date: $data->string('start_date'),
+        );
+    }
+}

--- a/src/DTO/RoleHistory.php
+++ b/src/DTO/RoleHistory.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\DTO;
+
+use NicolasKion\Esi\Support\Data;
+
+readonly class RoleHistory extends Dto
+{
+    /**
+     * @param  array<int, string>  $new_roles
+     * @param  array<int, string>  $old_roles
+     */
+    public function __construct(
+        public string $changed_at,
+        public int $character_id,
+        public int $issuer_id,
+        public array $new_roles,
+        public array $old_roles,
+        public string $role_type,
+    ) {}
+
+    public static function fromData(Data $data): self
+    {
+        return new self(
+            changed_at: $data->string('changed_at', ''),
+            character_id: $data->integer('character_id', 0),
+            issuer_id: $data->integer('issuer_id', 0),
+            new_roles: self::stringList($data->raw('new_roles')),
+            old_roles: self::stringList($data->raw('old_roles')),
+            role_type: $data->string('role_type', ''),
+        );
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private static function stringList(mixed $raw): array
+    {
+        if (! is_array($raw)) {
+            return [];
+        }
+
+        return array_values(array_map(
+            static fn (mixed $value): string => is_string($value) ? $value : '',
+            $raw,
+        ));
+    }
+}

--- a/src/DTO/Shareholder.php
+++ b/src/DTO/Shareholder.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\DTO;
+
+use NicolasKion\Esi\Support\Data;
+
+readonly class Shareholder extends Dto
+{
+    public function __construct(
+        public int $share_count,
+        public int $shareholder_id,
+        public string $shareholder_type,
+    ) {}
+
+    public static function fromData(Data $data): self
+    {
+        return new self(
+            share_count: $data->integer('share_count', 0),
+            shareholder_id: $data->integer('shareholder_id', 0),
+            shareholder_type: $data->string('shareholder_type', ''),
+        );
+    }
+}

--- a/src/DTO/Standing.php
+++ b/src/DTO/Standing.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\DTO;
+
+use NicolasKion\Esi\Support\Data;
+
+readonly class Standing extends Dto
+{
+    public function __construct(
+        public int $from_id,
+        public string $from_type,
+        public float $standing,
+    ) {}
+
+    public static function fromData(Data $data): self
+    {
+        return new self(
+            from_id: $data->integer('from_id', 0),
+            from_type: $data->string('from_type', ''),
+            standing: $data->float('standing', 0.0),
+        );
+    }
+}

--- a/src/DTO/Starbase.php
+++ b/src/DTO/Starbase.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\DTO;
+
+use NicolasKion\Esi\Support\Data;
+
+readonly class Starbase extends Dto
+{
+    public function __construct(
+        public ?int $moon_id,
+        public ?string $onlined_since,
+        public ?string $reinforced_until,
+        public int $starbase_id,
+        public ?string $state,
+        public int $system_id,
+        public int $type_id,
+        public ?string $unanchor_at,
+    ) {}
+
+    public static function fromData(Data $data): self
+    {
+        return new self(
+            moon_id: $data->integer('moon_id'),
+            onlined_since: $data->string('onlined_since'),
+            reinforced_until: $data->string('reinforced_until'),
+            starbase_id: $data->integer('starbase_id', 0),
+            state: $data->string('state'),
+            system_id: $data->integer('system_id', 0),
+            type_id: $data->integer('type_id', 0),
+            unanchor_at: $data->string('unanchor_at'),
+        );
+    }
+}

--- a/src/DTO/StarbaseDetail.php
+++ b/src/DTO/StarbaseDetail.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\DTO;
+
+use NicolasKion\Esi\Support\Data;
+
+readonly class StarbaseDetail extends Dto
+{
+    /**
+     * @param  array<int, StarbaseFuel>  $fuels
+     */
+    public function __construct(
+        public bool $allow_alliance_members,
+        public bool $allow_corporation_members,
+        public string $anchor,
+        public bool $attack_if_at_war,
+        public bool $attack_if_other_security_status_dropping,
+        public ?float $attack_security_status_threshold,
+        public ?float $attack_standing_threshold,
+        public string $fuel_bay_take,
+        public string $fuel_bay_view,
+        public array $fuels,
+        public string $offline,
+        public string $online,
+        public string $unanchor,
+        public bool $use_alliance_standings,
+    ) {}
+
+    public static function fromData(Data $data): self
+    {
+        return new self(
+            allow_alliance_members: $data->boolean('allow_alliance_members', false),
+            allow_corporation_members: $data->boolean('allow_corporation_members', false),
+            anchor: $data->string('anchor', ''),
+            attack_if_at_war: $data->boolean('attack_if_at_war', false),
+            attack_if_other_security_status_dropping: $data->boolean('attack_if_other_security_status_dropping', false),
+            attack_security_status_threshold: $data->float('attack_security_status_threshold'),
+            attack_standing_threshold: $data->float('attack_standing_threshold'),
+            fuel_bay_take: $data->string('fuel_bay_take', ''),
+            fuel_bay_view: $data->string('fuel_bay_view', ''),
+            fuels: $data->list('fuels', StarbaseFuel::fromData(...)),
+            offline: $data->string('offline', ''),
+            online: $data->string('online', ''),
+            unanchor: $data->string('unanchor', ''),
+            use_alliance_standings: $data->boolean('use_alliance_standings', false),
+        );
+    }
+}

--- a/src/DTO/StarbaseFuel.php
+++ b/src/DTO/StarbaseFuel.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\DTO;
+
+use NicolasKion\Esi\Support\Data;
+
+readonly class StarbaseFuel extends Dto
+{
+    public function __construct(
+        public int $quantity,
+        public int $type_id,
+    ) {}
+
+    public static function fromData(Data $data): self
+    {
+        return new self(
+            quantity: $data->integer('quantity', 0),
+            type_id: $data->integer('type_id', 0),
+        );
+    }
+}

--- a/src/Enums/EsiScope.php
+++ b/src/Enums/EsiScope.php
@@ -27,6 +27,16 @@ enum EsiScope: string
     case WriteCharacterContacts = 'esi-characters.write_contacts.v1';
     case ReadCorporationContacts = 'esi-corporations.read_contacts.v1';
     case ReadAllianceContacts = 'esi-alliances.read_contacts.v1';
+    case ReadCorporationBlueprints = 'esi-corporations.read_blueprints.v1';
+    case ReadCorporationContainerLogs = 'esi-corporations.read_container_logs.v1';
+    case ReadCorporationFacilities = 'esi-corporations.read_facilities.v1';
+    case ReadCorporationMedals = 'esi-corporations.read_medals.v1';
+    case ReadCorporationMembership = 'esi-corporations.read_corporation_membership.v1';
+    case TrackCorporationMembers = 'esi-corporations.track_members.v1';
+    case ReadCorporationTitles = 'esi-corporations.read_titles.v1';
+    case ReadCorporationWallets = 'esi-wallet.read_corporation_wallets.v1';
+    case ReadCorporationStandings = 'esi-corporations.read_standings.v1';
+    case ReadCorporationStarbases = 'esi-corporations.read_starbases.v1';
 
     /**
      * @return array<int, string>

--- a/src/Esi.php
+++ b/src/Esi.php
@@ -7,33 +7,44 @@ declare(strict_types=1);
 namespace NicolasKion\Esi;
 
 use NicolasKion\Esi\DTO\Alliance;
+use NicolasKion\Esi\DTO\AllianceHistory;
 use NicolasKion\Esi\DTO\AllianceIcons;
 use NicolasKion\Esi\DTO\Ancestry;
 use NicolasKion\Esi\DTO\Asset;
 use NicolasKion\Esi\DTO\AssetName;
 use NicolasKion\Esi\DTO\AsteroidBelt;
 use NicolasKion\Esi\DTO\Bloodline;
+use NicolasKion\Esi\DTO\Blueprint;
 use NicolasKion\Esi\DTO\CharacterAffiliation;
 use NicolasKion\Esi\DTO\CharacterContract;
 use NicolasKion\Esi\DTO\Constellation;
 use NicolasKion\Esi\DTO\Contact;
 use NicolasKion\Esi\DTO\ContactLabel;
+use NicolasKion\Esi\DTO\ContainerLog;
 use NicolasKion\Esi\DTO\Corporation;
 use NicolasKion\Esi\DTO\CorporationDivisions;
+use NicolasKion\Esi\DTO\CorporationIcons;
+use NicolasKion\Esi\DTO\CorporationMedal;
+use NicolasKion\Esi\DTO\CorporationRoles;
 use NicolasKion\Esi\DTO\CorporationStructure;
+use NicolasKion\Esi\DTO\CorporationTitle;
 use NicolasKion\Esi\DTO\DogmaAttribute;
 use NicolasKion\Esi\DTO\DogmaEffect;
 use NicolasKion\Esi\DTO\DogmaItem;
 use NicolasKion\Esi\DTO\EsiResult;
 use NicolasKion\Esi\DTO\EveMail;
+use NicolasKion\Esi\DTO\Facility;
 use NicolasKion\Esi\DTO\Faction;
 use NicolasKion\Esi\DTO\Graphic;
+use NicolasKion\Esi\DTO\IssuedMedal;
 use NicolasKion\Esi\DTO\Killmail;
 use NicolasKion\Esi\DTO\Location;
 use NicolasKion\Esi\DTO\MarketGroup;
 use NicolasKion\Esi\DTO\MarketHistory;
 use NicolasKion\Esi\DTO\MarketOrder;
 use NicolasKion\Esi\DTO\MarketPrice;
+use NicolasKion\Esi\DTO\MemberTitles;
+use NicolasKion\Esi\DTO\MemberTracking;
 use NicolasKion\Esi\DTO\Moon;
 use NicolasKion\Esi\DTO\Name;
 use NicolasKion\Esi\DTO\Online;
@@ -44,10 +55,15 @@ use NicolasKion\Esi\DTO\PublicContractItem;
 use NicolasKion\Esi\DTO\Race;
 use NicolasKion\Esi\DTO\RaidableSkyhook;
 use NicolasKion\Esi\DTO\Region;
+use NicolasKion\Esi\DTO\RoleHistory;
 use NicolasKion\Esi\DTO\Schematic;
+use NicolasKion\Esi\DTO\Shareholder;
 use NicolasKion\Esi\DTO\Ship;
 use NicolasKion\Esi\DTO\Sovereignty;
+use NicolasKion\Esi\DTO\Standing;
 use NicolasKion\Esi\DTO\Star;
+use NicolasKion\Esi\DTO\Starbase;
+use NicolasKion\Esi\DTO\StarbaseDetail;
 use NicolasKion\Esi\DTO\Stargate;
 use NicolasKion\Esi\DTO\Station;
 use NicolasKion\Esi\DTO\Status;
@@ -85,13 +101,31 @@ use NicolasKion\Esi\Requests\GetCharacterContractItemsRequest;
 use NicolasKion\Esi\Requests\GetCharacterContractsRequest;
 use NicolasKion\Esi\Requests\GetCharacterRequest;
 use NicolasKion\Esi\Requests\GetConstellationRequest;
+use NicolasKion\Esi\Requests\GetCorporationAllianceHistoryRequest;
 use NicolasKion\Esi\Requests\GetCorporationAssetNamesRequest;
 use NicolasKion\Esi\Requests\GetCorporationAssetsRequest;
+use NicolasKion\Esi\Requests\GetCorporationBlueprintsRequest;
 use NicolasKion\Esi\Requests\GetCorporationContactLabelsRequest;
 use NicolasKion\Esi\Requests\GetCorporationContactsRequest;
+use NicolasKion\Esi\Requests\GetCorporationContainerLogsRequest;
 use NicolasKion\Esi\Requests\GetCorporationDivisionsRequest;
+use NicolasKion\Esi\Requests\GetCorporationFacilitiesRequest;
+use NicolasKion\Esi\Requests\GetCorporationIconsRequest;
+use NicolasKion\Esi\Requests\GetCorporationIssuedMedalsRequest;
+use NicolasKion\Esi\Requests\GetCorporationMedalsRequest;
+use NicolasKion\Esi\Requests\GetCorporationMemberLimitRequest;
+use NicolasKion\Esi\Requests\GetCorporationMembersRequest;
+use NicolasKion\Esi\Requests\GetCorporationMemberTitlesRequest;
+use NicolasKion\Esi\Requests\GetCorporationMemberTrackingRequest;
 use NicolasKion\Esi\Requests\GetCorporationRequest;
+use NicolasKion\Esi\Requests\GetCorporationRolesHistoryRequest;
+use NicolasKion\Esi\Requests\GetCorporationRolesRequest;
+use NicolasKion\Esi\Requests\GetCorporationShareholdersRequest;
+use NicolasKion\Esi\Requests\GetCorporationStandingsRequest;
+use NicolasKion\Esi\Requests\GetCorporationStarbaseRequest;
+use NicolasKion\Esi\Requests\GetCorporationStarbasesRequest;
 use NicolasKion\Esi\Requests\GetCorporationStructuresRequest;
+use NicolasKion\Esi\Requests\GetCorporationTitlesRequest;
 use NicolasKion\Esi\Requests\GetDogmaAttributeRequest;
 use NicolasKion\Esi\Requests\GetDogmaAttributesRequest;
 use NicolasKion\Esi\Requests\GetDogmaEffectRequest;
@@ -112,6 +146,7 @@ use NicolasKion\Esi\Requests\GetMarketPricesRequest;
 use NicolasKion\Esi\Requests\GetMarketTypesRequest;
 use NicolasKion\Esi\Requests\GetMoonRequest;
 use NicolasKion\Esi\Requests\GetNamesRequest;
+use NicolasKion\Esi\Requests\GetNpcCorporationsRequest;
 use NicolasKion\Esi\Requests\GetOnlineRequest;
 use NicolasKion\Esi\Requests\GetPlanetRequest;
 use NicolasKion\Esi\Requests\GetPublicContractBidsRequest;
@@ -1326,6 +1361,253 @@ class Esi
     {
         $connector = new Connector;
         $request = new GetSystemKillsRequest;
+
+        return $connector->send($request);
+    }
+
+    /**
+     * Retrieves the IDs of NPC corporations.
+     *
+     * @return EsiResult<array<int, int>>
+     */
+    public function getNpcCorporations(): EsiResult
+    {
+        $connector = new Connector;
+        $request = new GetNpcCorporationsRequest;
+
+        return $connector->send($request);
+    }
+
+    /**
+     * Retrieves the alliance history of a corporation.
+     *
+     * @return EsiResult<array<int, AllianceHistory>>
+     */
+    public function getCorporationAllianceHistory(int $corporation_id): EsiResult
+    {
+        $connector = new Connector;
+        $request = new GetCorporationAllianceHistoryRequest($corporation_id);
+
+        return $connector->send($request);
+    }
+
+    /**
+     * Retrieves the icon URLs for a corporation.
+     *
+     * @return EsiResult<CorporationIcons>
+     */
+    public function getCorporationIcons(int $corporation_id): EsiResult
+    {
+        $connector = new Connector;
+        $request = new GetCorporationIconsRequest($corporation_id);
+
+        return $connector->send($request);
+    }
+
+    /**
+     * Retrieves the blueprints owned by a corporation.
+     *
+     * @return EsiResult<array<int, Blueprint>>
+     */
+    public function getCorporationBlueprints(Character $character, int $corporation_id): EsiResult
+    {
+        $connector = $this->getAuthenticatedConnector($character, EsiScope::ReadCorporationBlueprints);
+        $request = new GetCorporationBlueprintsRequest($corporation_id);
+
+        return $connector->sendPaginated($request);
+    }
+
+    /**
+     * Retrieves the recent access logs of a corporation's audit log secure containers.
+     *
+     * @return EsiResult<array<int, ContainerLog>>
+     */
+    public function getCorporationContainerLogs(Character $character, int $corporation_id): EsiResult
+    {
+        $connector = $this->getAuthenticatedConnector($character, EsiScope::ReadCorporationContainerLogs);
+        $request = new GetCorporationContainerLogsRequest($corporation_id);
+
+        return $connector->sendPaginated($request);
+    }
+
+    /**
+     * Retrieves a corporation's facilities.
+     *
+     * @return EsiResult<array<int, Facility>>
+     */
+    public function getCorporationFacilities(Character $character, int $corporation_id): EsiResult
+    {
+        $connector = $this->getAuthenticatedConnector($character, EsiScope::ReadCorporationFacilities);
+        $request = new GetCorporationFacilitiesRequest($corporation_id);
+
+        return $connector->send($request);
+    }
+
+    /**
+     * Retrieves the medals of a corporation.
+     *
+     * @return EsiResult<array<int, CorporationMedal>>
+     */
+    public function getCorporationMedals(Character $character, int $corporation_id): EsiResult
+    {
+        $connector = $this->getAuthenticatedConnector($character, EsiScope::ReadCorporationMedals);
+        $request = new GetCorporationMedalsRequest($corporation_id);
+
+        return $connector->sendPaginated($request);
+    }
+
+    /**
+     * Retrieves the medals issued by a corporation.
+     *
+     * @return EsiResult<array<int, IssuedMedal>>
+     */
+    public function getCorporationIssuedMedals(Character $character, int $corporation_id): EsiResult
+    {
+        $connector = $this->getAuthenticatedConnector($character, EsiScope::ReadCorporationMedals);
+        $request = new GetCorporationIssuedMedalsRequest($corporation_id);
+
+        return $connector->sendPaginated($request);
+    }
+
+    /**
+     * Retrieves the member character IDs of a corporation.
+     *
+     * @return EsiResult<array<int, int>>
+     */
+    public function getCorporationMembers(Character $character, int $corporation_id): EsiResult
+    {
+        $connector = $this->getAuthenticatedConnector($character, EsiScope::ReadCorporationMembership);
+        $request = new GetCorporationMembersRequest($corporation_id);
+
+        return $connector->send($request);
+    }
+
+    /**
+     * Retrieves the member limit of a corporation.
+     *
+     * @return EsiResult<int>
+     */
+    public function getCorporationMemberLimit(Character $character, int $corporation_id): EsiResult
+    {
+        $connector = $this->getAuthenticatedConnector($character, EsiScope::TrackCorporationMembers);
+        $request = new GetCorporationMemberLimitRequest($corporation_id);
+
+        return $connector->send($request);
+    }
+
+    /**
+     * Retrieves the titles held by each member of a corporation.
+     *
+     * @return EsiResult<array<int, MemberTitles>>
+     */
+    public function getCorporationMemberTitles(Character $character, int $corporation_id): EsiResult
+    {
+        $connector = $this->getAuthenticatedConnector($character, EsiScope::ReadCorporationTitles);
+        $request = new GetCorporationMemberTitlesRequest($corporation_id);
+
+        return $connector->send($request);
+    }
+
+    /**
+     * Retrieves the membertracking information of a corporation.
+     *
+     * @return EsiResult<array<int, MemberTracking>>
+     */
+    public function getCorporationMemberTracking(Character $character, int $corporation_id): EsiResult
+    {
+        $connector = $this->getAuthenticatedConnector($character, EsiScope::TrackCorporationMembers);
+        $request = new GetCorporationMemberTrackingRequest($corporation_id);
+
+        return $connector->send($request);
+    }
+
+    /**
+     * Retrieves the roles of each member of a corporation.
+     *
+     * @return EsiResult<array<int, CorporationRoles>>
+     */
+    public function getCorporationRoles(Character $character, int $corporation_id): EsiResult
+    {
+        $connector = $this->getAuthenticatedConnector($character, EsiScope::ReadCorporationMembership);
+        $request = new GetCorporationRolesRequest($corporation_id);
+
+        return $connector->send($request);
+    }
+
+    /**
+     * Retrieves the role change history of a corporation's members.
+     *
+     * @return EsiResult<array<int, RoleHistory>>
+     */
+    public function getCorporationRolesHistory(Character $character, int $corporation_id): EsiResult
+    {
+        $connector = $this->getAuthenticatedConnector($character, EsiScope::ReadCorporationMembership);
+        $request = new GetCorporationRolesHistoryRequest($corporation_id);
+
+        return $connector->sendPaginated($request);
+    }
+
+    /**
+     * Retrieves the shareholders of a corporation.
+     *
+     * @return EsiResult<array<int, Shareholder>>
+     */
+    public function getCorporationShareholders(Character $character, int $corporation_id): EsiResult
+    {
+        $connector = $this->getAuthenticatedConnector($character, EsiScope::ReadCorporationWallets);
+        $request = new GetCorporationShareholdersRequest($corporation_id);
+
+        return $connector->sendPaginated($request);
+    }
+
+    /**
+     * Retrieves the standings of a corporation.
+     *
+     * @return EsiResult<array<int, Standing>>
+     */
+    public function getCorporationStandings(Character $character, int $corporation_id): EsiResult
+    {
+        $connector = $this->getAuthenticatedConnector($character, EsiScope::ReadCorporationStandings);
+        $request = new GetCorporationStandingsRequest($corporation_id);
+
+        return $connector->sendPaginated($request);
+    }
+
+    /**
+     * Retrieves the starbases (POSes) of a corporation.
+     *
+     * @return EsiResult<array<int, Starbase>>
+     */
+    public function getCorporationStarbases(Character $character, int $corporation_id): EsiResult
+    {
+        $connector = $this->getAuthenticatedConnector($character, EsiScope::ReadCorporationStarbases);
+        $request = new GetCorporationStarbasesRequest($corporation_id);
+
+        return $connector->sendPaginated($request);
+    }
+
+    /**
+     * Retrieves detailed settings for a corporation starbase (POS).
+     *
+     * @return EsiResult<StarbaseDetail>
+     */
+    public function getCorporationStarbase(Character $character, int $corporation_id, int $starbase_id, int $system_id): EsiResult
+    {
+        $connector = $this->getAuthenticatedConnector($character, EsiScope::ReadCorporationStarbases);
+        $request = new GetCorporationStarbaseRequest($corporation_id, $starbase_id, $system_id);
+
+        return $connector->send($request);
+    }
+
+    /**
+     * Retrieves the member titles of a corporation.
+     *
+     * @return EsiResult<array<int, CorporationTitle>>
+     */
+    public function getCorporationTitles(Character $character, int $corporation_id): EsiResult
+    {
+        $connector = $this->getAuthenticatedConnector($character, EsiScope::ReadCorporationTitles);
+        $request = new GetCorporationTitlesRequest($corporation_id);
 
         return $connector->send($request);
     }

--- a/src/Requests/GetCorporationAllianceHistoryRequest.php
+++ b/src/Requests/GetCorporationAllianceHistoryRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\Requests;
+
+use Illuminate\Http\Client\Response;
+use NicolasKion\Esi\DTO\AllianceHistory;
+use NicolasKion\Esi\Request;
+
+/**
+ * @extends Request<array<int, AllianceHistory>>
+ */
+class GetCorporationAllianceHistoryRequest extends Request
+{
+    public function __construct(public int $corporation_id) {}
+
+    public function resolveEndpoint(): string
+    {
+        return sprintf('/corporations/%d/alliancehistory/', $this->corporation_id);
+    }
+
+    /**
+     * @return array<int, AllianceHistory>
+     */
+    public function createDto(Response $response, mixed $data): array
+    {
+        return AllianceHistory::hydrateList($data);
+    }
+}

--- a/src/Requests/GetCorporationBlueprintsRequest.php
+++ b/src/Requests/GetCorporationBlueprintsRequest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\Requests;
+
+use Illuminate\Http\Client\Response;
+use NicolasKion\Esi\DTO\Blueprint;
+use NicolasKion\Esi\Interfaces\WithPagination;
+use NicolasKion\Esi\Request;
+use NicolasKion\Esi\Traits\BasicPagination;
+
+/**
+ * @extends Request<array<int, Blueprint>>
+ *
+ * @implements WithPagination<array<int, Blueprint>>
+ */
+class GetCorporationBlueprintsRequest extends Request implements WithPagination
+{
+    use BasicPagination;
+
+    public function __construct(public int $corporation_id) {}
+
+    public function resolveEndpoint(): string
+    {
+        return sprintf('/corporations/%d/blueprints/', $this->corporation_id);
+    }
+
+    /**
+     * @return array<int, Blueprint>
+     */
+    public function createDto(Response $response, mixed $data): array
+    {
+        return Blueprint::hydrateList($data);
+    }
+}

--- a/src/Requests/GetCorporationContainerLogsRequest.php
+++ b/src/Requests/GetCorporationContainerLogsRequest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\Requests;
+
+use Illuminate\Http\Client\Response;
+use NicolasKion\Esi\DTO\ContainerLog;
+use NicolasKion\Esi\Interfaces\WithPagination;
+use NicolasKion\Esi\Request;
+use NicolasKion\Esi\Traits\BasicPagination;
+
+/**
+ * @extends Request<array<int, ContainerLog>>
+ *
+ * @implements WithPagination<array<int, ContainerLog>>
+ */
+class GetCorporationContainerLogsRequest extends Request implements WithPagination
+{
+    use BasicPagination;
+
+    public function __construct(public int $corporation_id) {}
+
+    public function resolveEndpoint(): string
+    {
+        return sprintf('/corporations/%d/containers/logs/', $this->corporation_id);
+    }
+
+    /**
+     * @return array<int, ContainerLog>
+     */
+    public function createDto(Response $response, mixed $data): array
+    {
+        return ContainerLog::hydrateList($data);
+    }
+}

--- a/src/Requests/GetCorporationFacilitiesRequest.php
+++ b/src/Requests/GetCorporationFacilitiesRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\Requests;
+
+use Illuminate\Http\Client\Response;
+use NicolasKion\Esi\DTO\Facility;
+use NicolasKion\Esi\Request;
+
+/**
+ * @extends Request<array<int, Facility>>
+ */
+class GetCorporationFacilitiesRequest extends Request
+{
+    public function __construct(public int $corporation_id) {}
+
+    public function resolveEndpoint(): string
+    {
+        return sprintf('/corporations/%d/facilities/', $this->corporation_id);
+    }
+
+    /**
+     * @return array<int, Facility>
+     */
+    public function createDto(Response $response, mixed $data): array
+    {
+        return Facility::hydrateList($data);
+    }
+}

--- a/src/Requests/GetCorporationIconsRequest.php
+++ b/src/Requests/GetCorporationIconsRequest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\Requests;
+
+use Illuminate\Http\Client\Response;
+use NicolasKion\Esi\DTO\CorporationIcons;
+use NicolasKion\Esi\Request;
+
+/**
+ * @extends Request<CorporationIcons>
+ */
+class GetCorporationIconsRequest extends Request
+{
+    public function __construct(public int $corporation_id) {}
+
+    public function resolveEndpoint(): string
+    {
+        return sprintf('/corporations/%d/icons/', $this->corporation_id);
+    }
+
+    public function createDto(Response $response, mixed $data): CorporationIcons
+    {
+        return CorporationIcons::hydrate($data);
+    }
+}

--- a/src/Requests/GetCorporationIssuedMedalsRequest.php
+++ b/src/Requests/GetCorporationIssuedMedalsRequest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\Requests;
+
+use Illuminate\Http\Client\Response;
+use NicolasKion\Esi\DTO\IssuedMedal;
+use NicolasKion\Esi\Interfaces\WithPagination;
+use NicolasKion\Esi\Request;
+use NicolasKion\Esi\Traits\BasicPagination;
+
+/**
+ * @extends Request<array<int, IssuedMedal>>
+ *
+ * @implements WithPagination<array<int, IssuedMedal>>
+ */
+class GetCorporationIssuedMedalsRequest extends Request implements WithPagination
+{
+    use BasicPagination;
+
+    public function __construct(public int $corporation_id) {}
+
+    public function resolveEndpoint(): string
+    {
+        return sprintf('/corporations/%d/medals/issued/', $this->corporation_id);
+    }
+
+    /**
+     * @return array<int, IssuedMedal>
+     */
+    public function createDto(Response $response, mixed $data): array
+    {
+        return IssuedMedal::hydrateList($data);
+    }
+}

--- a/src/Requests/GetCorporationMedalsRequest.php
+++ b/src/Requests/GetCorporationMedalsRequest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\Requests;
+
+use Illuminate\Http\Client\Response;
+use NicolasKion\Esi\DTO\CorporationMedal;
+use NicolasKion\Esi\Interfaces\WithPagination;
+use NicolasKion\Esi\Request;
+use NicolasKion\Esi\Traits\BasicPagination;
+
+/**
+ * @extends Request<array<int, CorporationMedal>>
+ *
+ * @implements WithPagination<array<int, CorporationMedal>>
+ */
+class GetCorporationMedalsRequest extends Request implements WithPagination
+{
+    use BasicPagination;
+
+    public function __construct(public int $corporation_id) {}
+
+    public function resolveEndpoint(): string
+    {
+        return sprintf('/corporations/%d/medals/', $this->corporation_id);
+    }
+
+    /**
+     * @return array<int, CorporationMedal>
+     */
+    public function createDto(Response $response, mixed $data): array
+    {
+        return CorporationMedal::hydrateList($data);
+    }
+}

--- a/src/Requests/GetCorporationMemberLimitRequest.php
+++ b/src/Requests/GetCorporationMemberLimitRequest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\Requests;
+
+use Illuminate\Http\Client\Response;
+use NicolasKion\Esi\Request;
+
+/**
+ * @extends Request<int>
+ */
+class GetCorporationMemberLimitRequest extends Request
+{
+    public function __construct(public int $corporation_id) {}
+
+    public function resolveEndpoint(): string
+    {
+        return sprintf('/corporations/%d/members/limit/', $this->corporation_id);
+    }
+
+    public function createDto(Response $response, mixed $data): int
+    {
+        return is_numeric($data) ? (int) $data : 0;
+    }
+}

--- a/src/Requests/GetCorporationMemberTitlesRequest.php
+++ b/src/Requests/GetCorporationMemberTitlesRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\Requests;
+
+use Illuminate\Http\Client\Response;
+use NicolasKion\Esi\DTO\MemberTitles;
+use NicolasKion\Esi\Request;
+
+/**
+ * @extends Request<array<int, MemberTitles>>
+ */
+class GetCorporationMemberTitlesRequest extends Request
+{
+    public function __construct(public int $corporation_id) {}
+
+    public function resolveEndpoint(): string
+    {
+        return sprintf('/corporations/%d/members/titles/', $this->corporation_id);
+    }
+
+    /**
+     * @return array<int, MemberTitles>
+     */
+    public function createDto(Response $response, mixed $data): array
+    {
+        return MemberTitles::hydrateList($data);
+    }
+}

--- a/src/Requests/GetCorporationMemberTrackingRequest.php
+++ b/src/Requests/GetCorporationMemberTrackingRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\Requests;
+
+use Illuminate\Http\Client\Response;
+use NicolasKion\Esi\DTO\MemberTracking;
+use NicolasKion\Esi\Request;
+
+/**
+ * @extends Request<array<int, MemberTracking>>
+ */
+class GetCorporationMemberTrackingRequest extends Request
+{
+    public function __construct(public int $corporation_id) {}
+
+    public function resolveEndpoint(): string
+    {
+        return sprintf('/corporations/%d/membertracking/', $this->corporation_id);
+    }
+
+    /**
+     * @return array<int, MemberTracking>
+     */
+    public function createDto(Response $response, mixed $data): array
+    {
+        return MemberTracking::hydrateList($data);
+    }
+}

--- a/src/Requests/GetCorporationMembersRequest.php
+++ b/src/Requests/GetCorporationMembersRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\Requests;
+
+use Illuminate\Http\Client\Response;
+use NicolasKion\Esi\Request;
+use NicolasKion\Esi\Support\Data;
+
+/**
+ * @extends Request<array<int, int>>
+ */
+class GetCorporationMembersRequest extends Request
+{
+    public function __construct(public int $corporation_id) {}
+
+    public function resolveEndpoint(): string
+    {
+        return sprintf('/corporations/%d/members/', $this->corporation_id);
+    }
+
+    /**
+     * @return array<int, int>
+     */
+    public function createDto(Response $response, mixed $data): array
+    {
+        return Data::integerList($data);
+    }
+}

--- a/src/Requests/GetCorporationRolesHistoryRequest.php
+++ b/src/Requests/GetCorporationRolesHistoryRequest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\Requests;
+
+use Illuminate\Http\Client\Response;
+use NicolasKion\Esi\DTO\RoleHistory;
+use NicolasKion\Esi\Interfaces\WithPagination;
+use NicolasKion\Esi\Request;
+use NicolasKion\Esi\Traits\BasicPagination;
+
+/**
+ * @extends Request<array<int, RoleHistory>>
+ *
+ * @implements WithPagination<array<int, RoleHistory>>
+ */
+class GetCorporationRolesHistoryRequest extends Request implements WithPagination
+{
+    use BasicPagination;
+
+    public function __construct(public int $corporation_id) {}
+
+    public function resolveEndpoint(): string
+    {
+        return sprintf('/corporations/%d/roles/history/', $this->corporation_id);
+    }
+
+    /**
+     * @return array<int, RoleHistory>
+     */
+    public function createDto(Response $response, mixed $data): array
+    {
+        return RoleHistory::hydrateList($data);
+    }
+}

--- a/src/Requests/GetCorporationRolesRequest.php
+++ b/src/Requests/GetCorporationRolesRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\Requests;
+
+use Illuminate\Http\Client\Response;
+use NicolasKion\Esi\DTO\CorporationRoles;
+use NicolasKion\Esi\Request;
+
+/**
+ * @extends Request<array<int, CorporationRoles>>
+ */
+class GetCorporationRolesRequest extends Request
+{
+    public function __construct(public int $corporation_id) {}
+
+    public function resolveEndpoint(): string
+    {
+        return sprintf('/corporations/%d/roles/', $this->corporation_id);
+    }
+
+    /**
+     * @return array<int, CorporationRoles>
+     */
+    public function createDto(Response $response, mixed $data): array
+    {
+        return CorporationRoles::hydrateList($data);
+    }
+}

--- a/src/Requests/GetCorporationShareholdersRequest.php
+++ b/src/Requests/GetCorporationShareholdersRequest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\Requests;
+
+use Illuminate\Http\Client\Response;
+use NicolasKion\Esi\DTO\Shareholder;
+use NicolasKion\Esi\Interfaces\WithPagination;
+use NicolasKion\Esi\Request;
+use NicolasKion\Esi\Traits\BasicPagination;
+
+/**
+ * @extends Request<array<int, Shareholder>>
+ *
+ * @implements WithPagination<array<int, Shareholder>>
+ */
+class GetCorporationShareholdersRequest extends Request implements WithPagination
+{
+    use BasicPagination;
+
+    public function __construct(public int $corporation_id) {}
+
+    public function resolveEndpoint(): string
+    {
+        return sprintf('/corporations/%d/shareholders/', $this->corporation_id);
+    }
+
+    /**
+     * @return array<int, Shareholder>
+     */
+    public function createDto(Response $response, mixed $data): array
+    {
+        return Shareholder::hydrateList($data);
+    }
+}

--- a/src/Requests/GetCorporationStandingsRequest.php
+++ b/src/Requests/GetCorporationStandingsRequest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\Requests;
+
+use Illuminate\Http\Client\Response;
+use NicolasKion\Esi\DTO\Standing;
+use NicolasKion\Esi\Interfaces\WithPagination;
+use NicolasKion\Esi\Request;
+use NicolasKion\Esi\Traits\BasicPagination;
+
+/**
+ * @extends Request<array<int, Standing>>
+ *
+ * @implements WithPagination<array<int, Standing>>
+ */
+class GetCorporationStandingsRequest extends Request implements WithPagination
+{
+    use BasicPagination;
+
+    public function __construct(public int $corporation_id) {}
+
+    public function resolveEndpoint(): string
+    {
+        return sprintf('/corporations/%d/standings/', $this->corporation_id);
+    }
+
+    /**
+     * @return array<int, Standing>
+     */
+    public function createDto(Response $response, mixed $data): array
+    {
+        return Standing::hydrateList($data);
+    }
+}

--- a/src/Requests/GetCorporationStarbaseRequest.php
+++ b/src/Requests/GetCorporationStarbaseRequest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\Requests;
+
+use Illuminate\Http\Client\Response;
+use NicolasKion\Esi\DTO\StarbaseDetail;
+use NicolasKion\Esi\Request;
+
+/**
+ * @extends Request<StarbaseDetail>
+ */
+class GetCorporationStarbaseRequest extends Request
+{
+    public function __construct(
+        public int $corporation_id,
+        public int $starbase_id,
+        public int $system_id,
+    ) {}
+
+    public function resolveEndpoint(): string
+    {
+        return sprintf('/corporations/%d/starbases/%d/', $this->corporation_id, $this->starbase_id);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getQuery(): array
+    {
+        return ['system_id' => $this->system_id];
+    }
+
+    public function createDto(Response $response, mixed $data): StarbaseDetail
+    {
+        return StarbaseDetail::hydrate($data);
+    }
+}

--- a/src/Requests/GetCorporationStarbasesRequest.php
+++ b/src/Requests/GetCorporationStarbasesRequest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\Requests;
+
+use Illuminate\Http\Client\Response;
+use NicolasKion\Esi\DTO\Starbase;
+use NicolasKion\Esi\Interfaces\WithPagination;
+use NicolasKion\Esi\Request;
+use NicolasKion\Esi\Traits\BasicPagination;
+
+/**
+ * @extends Request<array<int, Starbase>>
+ *
+ * @implements WithPagination<array<int, Starbase>>
+ */
+class GetCorporationStarbasesRequest extends Request implements WithPagination
+{
+    use BasicPagination;
+
+    public function __construct(public int $corporation_id) {}
+
+    public function resolveEndpoint(): string
+    {
+        return sprintf('/corporations/%d/starbases/', $this->corporation_id);
+    }
+
+    /**
+     * @return array<int, Starbase>
+     */
+    public function createDto(Response $response, mixed $data): array
+    {
+        return Starbase::hydrateList($data);
+    }
+}

--- a/src/Requests/GetCorporationTitlesRequest.php
+++ b/src/Requests/GetCorporationTitlesRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\Requests;
+
+use Illuminate\Http\Client\Response;
+use NicolasKion\Esi\DTO\CorporationTitle;
+use NicolasKion\Esi\Request;
+
+/**
+ * @extends Request<array<int, CorporationTitle>>
+ */
+class GetCorporationTitlesRequest extends Request
+{
+    public function __construct(public int $corporation_id) {}
+
+    public function resolveEndpoint(): string
+    {
+        return sprintf('/corporations/%d/titles/', $this->corporation_id);
+    }
+
+    /**
+     * @return array<int, CorporationTitle>
+     */
+    public function createDto(Response $response, mixed $data): array
+    {
+        return CorporationTitle::hydrateList($data);
+    }
+}

--- a/src/Requests/GetNpcCorporationsRequest.php
+++ b/src/Requests/GetNpcCorporationsRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\Requests;
+
+use Illuminate\Http\Client\Response;
+use NicolasKion\Esi\Request;
+use NicolasKion\Esi\Support\Data;
+
+/**
+ * @extends Request<array<int, int>>
+ */
+class GetNpcCorporationsRequest extends Request
+{
+    public function resolveEndpoint(): string
+    {
+        return '/corporations/npccorps/';
+    }
+
+    /**
+     * @return array<int, int>
+     */
+    public function createDto(Response $response, mixed $data): array
+    {
+        return Data::integerList($data);
+    }
+}

--- a/tests/CorporationExtraTest.php
+++ b/tests/CorporationExtraTest.php
@@ -1,0 +1,491 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Http;
+use NicolasKion\Esi\DTO\AllianceHistory;
+use NicolasKion\Esi\DTO\Blueprint;
+use NicolasKion\Esi\DTO\ContainerLog;
+use NicolasKion\Esi\DTO\CorporationIcons;
+use NicolasKion\Esi\DTO\CorporationMedal;
+use NicolasKion\Esi\DTO\CorporationRoles;
+use NicolasKion\Esi\DTO\CorporationTitle;
+use NicolasKion\Esi\DTO\Facility;
+use NicolasKion\Esi\DTO\IssuedMedal;
+use NicolasKion\Esi\DTO\MemberTitles;
+use NicolasKion\Esi\DTO\MemberTracking;
+use NicolasKion\Esi\DTO\RoleHistory;
+use NicolasKion\Esi\DTO\Shareholder;
+use NicolasKion\Esi\DTO\Standing;
+use NicolasKion\Esi\DTO\Starbase;
+use NicolasKion\Esi\DTO\StarbaseDetail;
+use NicolasKion\Esi\Esi;
+
+it('fetches the list of NPC corporation IDs', function (): void {
+    Http::fake([
+        'esi.evetech.net/corporations/npccorps/' => Http::response([1000001, 1000002]),
+    ]);
+
+    $result = (new Esi)->getNpcCorporations();
+
+    expect($result->wasSuccessful())->toBeTrue()
+        ->and($result->data)->toBe([1000001, 1000002]);
+});
+
+it('fetches and maps a corporation alliance history', function (): void {
+    Http::fake([
+        'esi.evetech.net/corporations/456/alliancehistory/' => Http::response(esiFixture('corporations/alliancehistory.json')),
+    ]);
+
+    $result = (new Esi)->getCorporationAllianceHistory(456);
+
+    expect($result->wasSuccessful())->toBeTrue()
+        ->and($result->data)->toHaveCount(1)
+        ->and($result->data[0])->toBeInstanceOf(AllianceHistory::class)
+        ->and($result->data[0]->alliance_id)->toBe(90000001)
+        ->and($result->data[0]->is_deleted)->toBeTrue()
+        ->and($result->data[0]->record_id)->toBe(90000001)
+        ->and($result->data[0]->start_date)->toBe('2026-06-09T12:00:00Z');
+});
+
+it('fetches and maps corporation icons', function (): void {
+    Http::fake([
+        'esi.evetech.net/corporations/456/icons/' => Http::response(esiFixture('corporations/icons.json')),
+    ]);
+
+    $result = (new Esi)->getCorporationIcons(456);
+
+    expect($result->wasSuccessful())->toBeTrue()
+        ->and($result->data)->toBeInstanceOf(CorporationIcons::class)
+        ->and($result->data->px128x128)->toBe('string')
+        ->and($result->data->px256x256)->toBe('string')
+        ->and($result->data->px64x64)->toBe('string');
+});
+
+it('fetches and maps paginated corporation blueprints', function (): void {
+    Http::fake([
+        'esi.evetech.net/corporations/456/blueprints/*' => Http::response([
+            [
+                'item_id' => 1,
+                'location_flag' => 'AssetSafety',
+                'location_id' => 2,
+                'material_efficiency' => 3,
+                'quantity' => 4,
+                'runs' => 5,
+                'time_efficiency' => 6,
+                'type_id' => 7,
+            ],
+        ], 200, ['X-Pages' => '1']),
+    ]);
+
+    $result = (new Esi)->getCorporationBlueprints(fakeCharacter(), 456);
+
+    expect($result->wasSuccessful())->toBeTrue()
+        ->and($result->data)->toHaveCount(1)
+        ->and($result->data[0])->toBeInstanceOf(Blueprint::class)
+        ->and($result->data[0]->item_id)->toBe(1)
+        ->and($result->data[0]->location_flag)->toBe('AssetSafety')
+        ->and($result->data[0]->location_id)->toBe(2)
+        ->and($result->data[0]->material_efficiency)->toBe(3)
+        ->and($result->data[0]->quantity)->toBe(4)
+        ->and($result->data[0]->runs)->toBe(5)
+        ->and($result->data[0]->time_efficiency)->toBe(6)
+        ->and($result->data[0]->type_id)->toBe(7);
+});
+
+it('fetches and maps paginated corporation container logs', function (): void {
+    Http::fake([
+        'esi.evetech.net/corporations/456/containers/logs/*' => Http::response([
+            [
+                'action' => 'add',
+                'character_id' => 90000001,
+                'container_id' => 90000002,
+                'container_type_id' => 90000003,
+                'location_flag' => 'AssetSafety',
+                'location_id' => 90000004,
+                'logged_at' => '2026-06-09T12:00:00Z',
+                'new_config_bitmask' => 1,
+                'old_config_bitmask' => 2,
+                'password_type' => 'config',
+                'quantity' => 3,
+                'type_id' => 90000005,
+            ],
+        ], 200, ['X-Pages' => '1']),
+    ]);
+
+    $result = (new Esi)->getCorporationContainerLogs(fakeCharacter(), 456);
+
+    expect($result->wasSuccessful())->toBeTrue()
+        ->and($result->data)->toHaveCount(1)
+        ->and($result->data[0])->toBeInstanceOf(ContainerLog::class)
+        ->and($result->data[0]->action)->toBe('add')
+        ->and($result->data[0]->character_id)->toBe(90000001)
+        ->and($result->data[0]->container_id)->toBe(90000002)
+        ->and($result->data[0]->container_type_id)->toBe(90000003)
+        ->and($result->data[0]->location_flag)->toBe('AssetSafety')
+        ->and($result->data[0]->location_id)->toBe(90000004)
+        ->and($result->data[0]->logged_at)->toBe('2026-06-09T12:00:00Z')
+        ->and($result->data[0]->new_config_bitmask)->toBe(1)
+        ->and($result->data[0]->old_config_bitmask)->toBe(2)
+        ->and($result->data[0]->password_type)->toBe('config')
+        ->and($result->data[0]->quantity)->toBe(3)
+        ->and($result->data[0]->type_id)->toBe(90000005);
+});
+
+it('fetches and maps corporation facilities', function (): void {
+    Http::fake([
+        'esi.evetech.net/corporations/456/facilities/' => Http::response([
+            ['facility_id' => 1, 'system_id' => 2, 'type_id' => 3],
+        ]),
+    ]);
+
+    $result = (new Esi)->getCorporationFacilities(fakeCharacter(), 456);
+
+    expect($result->wasSuccessful())->toBeTrue()
+        ->and($result->data)->toHaveCount(1)
+        ->and($result->data[0])->toBeInstanceOf(Facility::class)
+        ->and($result->data[0]->facility_id)->toBe(1)
+        ->and($result->data[0]->system_id)->toBe(2)
+        ->and($result->data[0]->type_id)->toBe(3);
+});
+
+it('fetches and maps paginated corporation medals', function (): void {
+    Http::fake([
+        'esi.evetech.net/corporations/456/medals/*' => Http::response([
+            [
+                'created_at' => '2026-06-09T12:00:00Z',
+                'creator_id' => 1,
+                'description' => 'string',
+                'medal_id' => 2,
+                'title' => 'string',
+            ],
+        ], 200, ['X-Pages' => '1']),
+    ]);
+
+    $result = (new Esi)->getCorporationMedals(fakeCharacter(), 456);
+
+    expect($result->wasSuccessful())->toBeTrue()
+        ->and($result->data)->toHaveCount(1)
+        ->and($result->data[0])->toBeInstanceOf(CorporationMedal::class)
+        ->and($result->data[0]->created_at)->toBe('2026-06-09T12:00:00Z')
+        ->and($result->data[0]->creator_id)->toBe(1)
+        ->and($result->data[0]->description)->toBe('string')
+        ->and($result->data[0]->medal_id)->toBe(2)
+        ->and($result->data[0]->title)->toBe('string');
+});
+
+it('fetches and maps paginated corporation issued medals', function (): void {
+    Http::fake([
+        'esi.evetech.net/corporations/456/medals/issued/*' => Http::response([
+            [
+                'character_id' => 1,
+                'issued_at' => '2026-06-09T12:00:00Z',
+                'issuer_id' => 2,
+                'medal_id' => 3,
+                'reason' => 'string',
+                'status' => 'private',
+            ],
+        ], 200, ['X-Pages' => '1']),
+    ]);
+
+    $result = (new Esi)->getCorporationIssuedMedals(fakeCharacter(), 456);
+
+    expect($result->wasSuccessful())->toBeTrue()
+        ->and($result->data)->toHaveCount(1)
+        ->and($result->data[0])->toBeInstanceOf(IssuedMedal::class)
+        ->and($result->data[0]->character_id)->toBe(1)
+        ->and($result->data[0]->issued_at)->toBe('2026-06-09T12:00:00Z')
+        ->and($result->data[0]->issuer_id)->toBe(2)
+        ->and($result->data[0]->medal_id)->toBe(3)
+        ->and($result->data[0]->reason)->toBe('string')
+        ->and($result->data[0]->status)->toBe('private');
+});
+
+it('fetches the list of corporation member character IDs', function (): void {
+    Http::fake([
+        'esi.evetech.net/corporations/456/members/' => Http::response([90000001, 90000002]),
+    ]);
+
+    $result = (new Esi)->getCorporationMembers(fakeCharacter(), 456);
+
+    expect($result->wasSuccessful())->toBeTrue()
+        ->and($result->data)->toBe([90000001, 90000002]);
+});
+
+it('fetches the corporation member limit', function (): void {
+    Http::fake([
+        'esi.evetech.net/corporations/456/members/limit/' => Http::response('9001', 200, ['Content-Type' => 'application/json']),
+    ]);
+
+    $result = (new Esi)->getCorporationMemberLimit(fakeCharacter(), 456);
+
+    expect($result->wasSuccessful())->toBeTrue()
+        ->and($result->data)->toBe(9001);
+});
+
+it('fetches and maps corporation member titles', function (): void {
+    Http::fake([
+        'esi.evetech.net/corporations/456/members/titles/' => Http::response([
+            ['character_id' => 90000001, 'titles' => [1, 2, 3]],
+        ]),
+    ]);
+
+    $result = (new Esi)->getCorporationMemberTitles(fakeCharacter(), 456);
+
+    expect($result->wasSuccessful())->toBeTrue()
+        ->and($result->data)->toHaveCount(1)
+        ->and($result->data[0])->toBeInstanceOf(MemberTitles::class)
+        ->and($result->data[0]->character_id)->toBe(90000001)
+        ->and($result->data[0]->titles)->toBe([1, 2, 3]);
+});
+
+it('fetches and maps corporation member tracking', function (): void {
+    Http::fake([
+        'esi.evetech.net/corporations/456/membertracking/' => Http::response([
+            [
+                'base_id' => 1,
+                'character_id' => 90000001,
+                'location_id' => 2,
+                'logoff_date' => '2026-06-09T12:00:00Z',
+                'logon_date' => '2026-06-08T12:00:00Z',
+                'ship_type_id' => 3,
+                'start_date' => '2026-06-01T12:00:00Z',
+            ],
+        ]),
+    ]);
+
+    $result = (new Esi)->getCorporationMemberTracking(fakeCharacter(), 456);
+
+    expect($result->wasSuccessful())->toBeTrue()
+        ->and($result->data)->toHaveCount(1)
+        ->and($result->data[0])->toBeInstanceOf(MemberTracking::class)
+        ->and($result->data[0]->base_id)->toBe(1)
+        ->and($result->data[0]->character_id)->toBe(90000001)
+        ->and($result->data[0]->location_id)->toBe(2)
+        ->and($result->data[0]->logoff_date)->toBe('2026-06-09T12:00:00Z')
+        ->and($result->data[0]->logon_date)->toBe('2026-06-08T12:00:00Z')
+        ->and($result->data[0]->ship_type_id)->toBe(3)
+        ->and($result->data[0]->start_date)->toBe('2026-06-01T12:00:00Z');
+});
+
+it('fetches and maps corporation member roles', function (): void {
+    Http::fake([
+        'esi.evetech.net/corporations/456/roles/' => Http::response([
+            [
+                'character_id' => 90000001,
+                'grantable_roles' => ['Account_Take_1', 456],
+                'grantable_roles_at_base' => ['Account_Take_1'],
+                'grantable_roles_at_hq' => ['Account_Take_1'],
+                'grantable_roles_at_other' => ['Account_Take_1'],
+                'roles' => ['Director'],
+                'roles_at_base' => ['Director'],
+                'roles_at_hq' => ['Director'],
+                'roles_at_other' => ['Director'],
+            ],
+            [
+                // A sparse entry: every role array field is absent.
+                'character_id' => 90000002,
+            ],
+        ]),
+    ]);
+
+    $result = (new Esi)->getCorporationRoles(fakeCharacter(), 456);
+
+    expect($result->wasSuccessful())->toBeTrue()
+        ->and($result->data)->toHaveCount(2)
+        ->and($result->data[0])->toBeInstanceOf(CorporationRoles::class)
+        ->and($result->data[0]->character_id)->toBe(90000001)
+        ->and($result->data[0]->grantable_roles)->toBe(['Account_Take_1', ''])
+        ->and($result->data[0]->grantable_roles_at_base)->toBe(['Account_Take_1'])
+        ->and($result->data[0]->grantable_roles_at_hq)->toBe(['Account_Take_1'])
+        ->and($result->data[0]->grantable_roles_at_other)->toBe(['Account_Take_1'])
+        ->and($result->data[0]->roles)->toBe(['Director'])
+        ->and($result->data[0]->roles_at_base)->toBe(['Director'])
+        ->and($result->data[0]->roles_at_hq)->toBe(['Director'])
+        ->and($result->data[0]->roles_at_other)->toBe(['Director'])
+        ->and($result->data[1]->character_id)->toBe(90000002)
+        ->and($result->data[1]->grantable_roles)->toBe([])
+        ->and($result->data[1]->roles)->toBe([]);
+});
+
+it('fetches and maps paginated corporation roles history', function (): void {
+    Http::fake([
+        'esi.evetech.net/corporations/456/roles/history/*' => Http::response([
+            [
+                'changed_at' => '2026-06-09T12:00:00Z',
+                'character_id' => 90000001,
+                'issuer_id' => 90000002,
+                'new_roles' => ['Director', 123],
+                'old_roles' => ['Accountant'],
+                'role_type' => 'grantable_roles',
+            ],
+            [
+                'changed_at' => '2026-06-10T12:00:00Z',
+                'character_id' => 90000003,
+                'issuer_id' => 90000004,
+                'role_type' => 'roles',
+            ],
+        ], 200, ['X-Pages' => '1']),
+    ]);
+
+    $result = (new Esi)->getCorporationRolesHistory(fakeCharacter(), 456);
+
+    expect($result->wasSuccessful())->toBeTrue()
+        ->and($result->data)->toHaveCount(2)
+        ->and($result->data[0])->toBeInstanceOf(RoleHistory::class)
+        ->and($result->data[0]->changed_at)->toBe('2026-06-09T12:00:00Z')
+        ->and($result->data[0]->character_id)->toBe(90000001)
+        ->and($result->data[0]->issuer_id)->toBe(90000002)
+        ->and($result->data[0]->new_roles)->toBe(['Director', ''])
+        ->and($result->data[0]->old_roles)->toBe(['Accountant'])
+        ->and($result->data[0]->role_type)->toBe('grantable_roles')
+        ->and($result->data[1]->new_roles)->toBe([])
+        ->and($result->data[1]->old_roles)->toBe([]);
+});
+
+it('fetches and maps paginated corporation shareholders', function (): void {
+    Http::fake([
+        'esi.evetech.net/corporations/456/shareholders/*' => Http::response([
+            ['share_count' => 1000, 'shareholder_id' => 90000001, 'shareholder_type' => 'character'],
+        ], 200, ['X-Pages' => '1']),
+    ]);
+
+    $result = (new Esi)->getCorporationShareholders(fakeCharacter(), 456);
+
+    expect($result->wasSuccessful())->toBeTrue()
+        ->and($result->data)->toHaveCount(1)
+        ->and($result->data[0])->toBeInstanceOf(Shareholder::class)
+        ->and($result->data[0]->share_count)->toBe(1000)
+        ->and($result->data[0]->shareholder_id)->toBe(90000001)
+        ->and($result->data[0]->shareholder_type)->toBe('character');
+});
+
+it('fetches and maps paginated corporation standings', function (): void {
+    Http::fake([
+        'esi.evetech.net/corporations/456/standings/*' => Http::response([
+            ['from_id' => 90000001, 'from_type' => 'agent', 'standing' => 1.5],
+        ], 200, ['X-Pages' => '1']),
+    ]);
+
+    $result = (new Esi)->getCorporationStandings(fakeCharacter(), 456);
+
+    expect($result->wasSuccessful())->toBeTrue()
+        ->and($result->data)->toHaveCount(1)
+        ->and($result->data[0])->toBeInstanceOf(Standing::class)
+        ->and($result->data[0]->from_id)->toBe(90000001)
+        ->and($result->data[0]->from_type)->toBe('agent')
+        ->and($result->data[0]->standing)->toBe(1.5);
+});
+
+it('fetches and maps paginated corporation starbases', function (): void {
+    Http::fake([
+        'esi.evetech.net/corporations/456/starbases/*' => Http::response([
+            [
+                'moon_id' => 1,
+                'onlined_since' => '2026-06-09T12:00:00Z',
+                'reinforced_until' => '2026-06-10T12:00:00Z',
+                'starbase_id' => 90000001,
+                'state' => 'online',
+                'system_id' => 2,
+                'type_id' => 3,
+                'unanchor_at' => '2026-06-11T12:00:00Z',
+            ],
+        ], 200, ['X-Pages' => '1']),
+    ]);
+
+    $result = (new Esi)->getCorporationStarbases(fakeCharacter(), 456);
+
+    expect($result->wasSuccessful())->toBeTrue()
+        ->and($result->data)->toHaveCount(1)
+        ->and($result->data[0])->toBeInstanceOf(Starbase::class)
+        ->and($result->data[0]->moon_id)->toBe(1)
+        ->and($result->data[0]->onlined_since)->toBe('2026-06-09T12:00:00Z')
+        ->and($result->data[0]->reinforced_until)->toBe('2026-06-10T12:00:00Z')
+        ->and($result->data[0]->starbase_id)->toBe(90000001)
+        ->and($result->data[0]->state)->toBe('online')
+        ->and($result->data[0]->system_id)->toBe(2)
+        ->and($result->data[0]->type_id)->toBe(3)
+        ->and($result->data[0]->unanchor_at)->toBe('2026-06-11T12:00:00Z');
+});
+
+it('fetches and maps a single corporation starbase with the required system_id query param', function (): void {
+    Http::fake([
+        'esi.evetech.net/corporations/456/starbases/90000001/*' => Http::response(esiFixture('corporations/starbase.json')),
+    ]);
+
+    $result = (new Esi)->getCorporationStarbase(fakeCharacter(), 456, 90000001, 30000142);
+
+    expect($result->wasSuccessful())->toBeTrue()
+        ->and($result->data)->toBeInstanceOf(StarbaseDetail::class)
+        ->and($result->data->allow_alliance_members)->toBeTrue()
+        ->and($result->data->allow_corporation_members)->toBeTrue()
+        ->and($result->data->anchor)->toBe('alliance_member')
+        ->and($result->data->attack_if_at_war)->toBeTrue()
+        ->and($result->data->attack_if_other_security_status_dropping)->toBeTrue()
+        ->and($result->data->attack_security_status_threshold)->toBe(1.5)
+        ->and($result->data->attack_standing_threshold)->toBe(1.5)
+        ->and($result->data->fuel_bay_take)->toBe('alliance_member')
+        ->and($result->data->fuel_bay_view)->toBe('alliance_member')
+        ->and($result->data->fuels)->toHaveCount(1)
+        ->and($result->data->fuels[0]->quantity)->toBe(90000001)
+        ->and($result->data->fuels[0]->type_id)->toBe(90000001)
+        ->and($result->data->offline)->toBe('alliance_member')
+        ->and($result->data->online)->toBe('alliance_member')
+        ->and($result->data->unanchor)->toBe('alliance_member')
+        ->and($result->data->use_alliance_standings)->toBeTrue();
+
+    Http::assertSent(fn ($request) => str_contains($request->url(), 'system_id=30000142'));
+});
+
+it('fetches and maps corporation titles', function (): void {
+    Http::fake([
+        'esi.evetech.net/corporations/456/titles/' => Http::response([
+            [
+                'grantable_roles' => ['Account_Take_1', 456],
+                'grantable_roles_at_base' => ['Account_Take_1'],
+                'grantable_roles_at_hq' => ['Account_Take_1'],
+                'grantable_roles_at_other' => ['Account_Take_1'],
+                'name' => 'string',
+                'roles' => ['Director'],
+                'roles_at_base' => ['Director'],
+                'roles_at_hq' => ['Director'],
+                'roles_at_other' => ['Director'],
+                'title_id' => 90000001,
+            ],
+            [
+                // A sparse entry: every array field is absent, name/title_id are null.
+            ],
+        ]),
+    ]);
+
+    $result = (new Esi)->getCorporationTitles(fakeCharacter(), 456);
+
+    expect($result->wasSuccessful())->toBeTrue()
+        ->and($result->data)->toHaveCount(2)
+        ->and($result->data[0])->toBeInstanceOf(CorporationTitle::class)
+        ->and($result->data[0]->grantable_roles)->toBe(['Account_Take_1', ''])
+        ->and($result->data[0]->grantable_roles_at_base)->toBe(['Account_Take_1'])
+        ->and($result->data[0]->grantable_roles_at_hq)->toBe(['Account_Take_1'])
+        ->and($result->data[0]->grantable_roles_at_other)->toBe(['Account_Take_1'])
+        ->and($result->data[0]->name)->toBe('string')
+        ->and($result->data[0]->roles)->toBe(['Director'])
+        ->and($result->data[0]->roles_at_base)->toBe(['Director'])
+        ->and($result->data[0]->roles_at_hq)->toBe(['Director'])
+        ->and($result->data[0]->roles_at_other)->toBe(['Director'])
+        ->and($result->data[0]->title_id)->toBe(90000001)
+        ->and($result->data[1]->grantable_roles)->toBe([])
+        ->and($result->data[1]->roles)->toBe([])
+        ->and($result->data[1]->name)->toBeNull()
+        ->and($result->data[1]->title_id)->toBeNull();
+});
+
+it('returns an error result when a corporation endpoint fails with a server error', function (): void {
+    Http::fake([
+        'esi.evetech.net/corporations/456/facilities/' => Http::response(['error' => 'Internal server error'], 500),
+    ]);
+
+    $result = (new Esi)->getCorporationFacilities(fakeCharacter(), 456);
+
+    expect($result->failed())->toBeTrue()
+        ->and($result->error?->code)->toBe(500);
+});

--- a/tests/Fixtures/corporations/alliancehistory.json
+++ b/tests/Fixtures/corporations/alliancehistory.json
@@ -1,0 +1,8 @@
+[
+    {
+        "alliance_id": 90000001,
+        "is_deleted": true,
+        "record_id": 90000001,
+        "start_date": "2026-06-09T12:00:00Z"
+    }
+]

--- a/tests/Fixtures/corporations/icons.json
+++ b/tests/Fixtures/corporations/icons.json
@@ -1,0 +1,5 @@
+{
+    "px128x128": "string",
+    "px256x256": "string",
+    "px64x64": "string"
+}

--- a/tests/Fixtures/corporations/starbase.json
+++ b/tests/Fixtures/corporations/starbase.json
@@ -1,0 +1,21 @@
+{
+    "allow_alliance_members": true,
+    "allow_corporation_members": true,
+    "anchor": "alliance_member",
+    "attack_if_at_war": true,
+    "attack_if_other_security_status_dropping": true,
+    "attack_security_status_threshold": 1.5,
+    "attack_standing_threshold": 1.5,
+    "fuel_bay_take": "alliance_member",
+    "fuel_bay_view": "alliance_member",
+    "fuels": [
+        {
+            "quantity": 90000001,
+            "type_id": 90000001
+        }
+    ],
+    "offline": "alliance_member",
+    "online": "alliance_member",
+    "unanchor": "alliance_member",
+    "use_alliance_standings": true
+}


### PR DESCRIPTION
Completes the Corporation domain (19 endpoints): public npccorps/alliance-history/icons and the authenticated members/roles/medals/blueprints/facilities/standings/starbases/titles/shareholders/container-logs. 17 DTOs, 19 requests, 10 new scopes. PHPStan level 9 clean, 100% coverage (158 tests).