### PR TITLE
feat: add remaining character endpoints

### DIFF
--- a/src/DTO/AgentResearch.php
+++ b/src/DTO/AgentResearch.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\DTO;
+
+use NicolasKion\Esi\Support\Data;
+
+readonly class AgentResearch extends Dto
+{
+    public function __construct(
+        public int $agent_id,
+        public float $points_per_day,
+        public float $remainder_points,
+        public int $skill_type_id,
+        public string $started_at,
+    ) {}
+
+    public static function fromData(Data $data): self
+    {
+        return new self(
+            agent_id: $data->integer('agent_id', 0),
+            points_per_day: $data->float('points_per_day', 0.0),
+            remainder_points: $data->float('remainder_points', 0.0),
+            skill_type_id: $data->integer('skill_type_id', 0),
+            started_at: $data->string('started_at', ''),
+        );
+    }
+}

--- a/src/DTO/CharacterMedal.php
+++ b/src/DTO/CharacterMedal.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\DTO;
+
+use NicolasKion\Esi\Support\Data;
+
+readonly class CharacterMedal extends Dto
+{
+    /**
+     * @param  array<int, MedalGraphic>  $graphics
+     */
+    public function __construct(
+        public int $corporation_id,
+        public string $date,
+        public string $description,
+        public array $graphics,
+        public int $issuer_id,
+        public int $medal_id,
+        public string $reason,
+        public string $status,
+        public string $title,
+    ) {}
+
+    public static function fromData(Data $data): self
+    {
+        return new self(
+            corporation_id: $data->integer('corporation_id', 0),
+            date: $data->string('date', ''),
+            description: $data->string('description', ''),
+            graphics: $data->list('graphics', MedalGraphic::fromData(...)),
+            issuer_id: $data->integer('issuer_id', 0),
+            medal_id: $data->integer('medal_id', 0),
+            reason: $data->string('reason', ''),
+            status: $data->string('status', ''),
+            title: $data->string('title', ''),
+        );
+    }
+}

--- a/src/DTO/CharacterPortrait.php
+++ b/src/DTO/CharacterPortrait.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\DTO;
+
+use NicolasKion\Esi\Support\Data;
+
+readonly class CharacterPortrait extends Dto
+{
+    public function __construct(
+        public ?string $px128x128,
+        public ?string $px256x256,
+        public ?string $px512x512,
+        public ?string $px64x64,
+    ) {}
+
+    public static function fromData(Data $data): self
+    {
+        return new self(
+            px128x128: $data->string('px128x128'),
+            px256x256: $data->string('px256x256'),
+            px512x512: $data->string('px512x512'),
+            px64x64: $data->string('px64x64'),
+        );
+    }
+}

--- a/src/DTO/CharacterRoles.php
+++ b/src/DTO/CharacterRoles.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\DTO;
+
+use NicolasKion\Esi\Support\Data;
+
+readonly class CharacterRoles extends Dto
+{
+    /**
+     * @param  array<int, string>  $roles
+     * @param  array<int, string>  $roles_at_base
+     * @param  array<int, string>  $roles_at_hq
+     * @param  array<int, string>  $roles_at_other
+     */
+    public function __construct(
+        public array $roles,
+        public array $roles_at_base,
+        public array $roles_at_hq,
+        public array $roles_at_other,
+    ) {}
+
+    public static function fromData(Data $data): self
+    {
+        return new self(
+            roles: self::stringList($data->raw('roles')),
+            roles_at_base: self::stringList($data->raw('roles_at_base')),
+            roles_at_hq: self::stringList($data->raw('roles_at_hq')),
+            roles_at_other: self::stringList($data->raw('roles_at_other')),
+        );
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private static function stringList(mixed $raw): array
+    {
+        if (! is_array($raw)) {
+            return [];
+        }
+
+        return array_values(array_map(
+            static fn (mixed $value): string => is_string($value) ? $value : '',
+            $raw,
+        ));
+    }
+}

--- a/src/DTO/CharacterTitle.php
+++ b/src/DTO/CharacterTitle.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\DTO;
+
+use NicolasKion\Esi\Support\Data;
+
+readonly class CharacterTitle extends Dto
+{
+    public function __construct(
+        public ?string $name,
+        public ?int $title_id,
+    ) {}
+
+    public static function fromData(Data $data): self
+    {
+        return new self(
+            name: $data->string('name'),
+            title_id: $data->integer('title_id'),
+        );
+    }
+}

--- a/src/DTO/ContactNotification.php
+++ b/src/DTO/ContactNotification.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\DTO;
+
+use NicolasKion\Esi\Support\Data;
+
+readonly class ContactNotification extends Dto
+{
+    public function __construct(
+        public string $message,
+        public int $notification_id,
+        public string $send_date,
+        public int $sender_character_id,
+        public float $standing_level,
+    ) {}
+
+    public static function fromData(Data $data): self
+    {
+        return new self(
+            message: $data->string('message', ''),
+            notification_id: $data->integer('notification_id', 0),
+            send_date: $data->string('send_date', ''),
+            sender_character_id: $data->integer('sender_character_id', 0),
+            standing_level: $data->float('standing_level', 0.0),
+        );
+    }
+}

--- a/src/DTO/CorporationHistory.php
+++ b/src/DTO/CorporationHistory.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\DTO;
+
+use NicolasKion\Esi\Support\Data;
+
+readonly class CorporationHistory extends Dto
+{
+    public function __construct(
+        public int $corporation_id,
+        public ?bool $is_deleted,
+        public int $record_id,
+        public string $start_date,
+    ) {}
+
+    public static function fromData(Data $data): self
+    {
+        return new self(
+            corporation_id: $data->integer('corporation_id', 0),
+            is_deleted: $data->boolean('is_deleted'),
+            record_id: $data->integer('record_id', 0),
+            start_date: $data->string('start_date', ''),
+        );
+    }
+}

--- a/src/DTO/JumpFatigue.php
+++ b/src/DTO/JumpFatigue.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\DTO;
+
+use NicolasKion\Esi\Support\Data;
+
+readonly class JumpFatigue extends Dto
+{
+    public function __construct(
+        public ?string $jump_fatigue_expire_date,
+        public ?string $last_jump_date,
+        public ?string $last_update_date,
+    ) {}
+
+    public static function fromData(Data $data): self
+    {
+        return new self(
+            jump_fatigue_expire_date: $data->string('jump_fatigue_expire_date'),
+            last_jump_date: $data->string('last_jump_date'),
+            last_update_date: $data->string('last_update_date'),
+        );
+    }
+}

--- a/src/DTO/MedalGraphic.php
+++ b/src/DTO/MedalGraphic.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\DTO;
+
+use NicolasKion\Esi\Support\Data;
+
+readonly class MedalGraphic extends Dto
+{
+    public function __construct(
+        public ?int $color,
+        public string $graphic,
+        public int $layer,
+        public int $part,
+    ) {}
+
+    public static function fromData(Data $data): self
+    {
+        return new self(
+            color: $data->integer('color'),
+            graphic: $data->string('graphic', ''),
+            layer: $data->integer('layer', 0),
+            part: $data->integer('part', 0),
+        );
+    }
+}

--- a/src/DTO/Notification.php
+++ b/src/DTO/Notification.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\DTO;
+
+use NicolasKion\Esi\Support\Data;
+
+readonly class Notification extends Dto
+{
+    public function __construct(
+        public ?bool $is_read,
+        public int $notification_id,
+        public int $sender_id,
+        public string $sender_type,
+        public ?string $text,
+        public string $timestamp,
+        public string $type,
+    ) {}
+
+    public static function fromData(Data $data): self
+    {
+        return new self(
+            is_read: $data->boolean('is_read'),
+            notification_id: $data->integer('notification_id', 0),
+            sender_id: $data->integer('sender_id', 0),
+            sender_type: $data->string('sender_type', ''),
+            text: $data->string('text'),
+            timestamp: $data->string('timestamp', ''),
+            type: $data->string('type', ''),
+        );
+    }
+}

--- a/src/Enums/EsiScope.php
+++ b/src/Enums/EsiScope.php
@@ -37,6 +37,14 @@ enum EsiScope: string
     case ReadCorporationWallets = 'esi-wallet.read_corporation_wallets.v1';
     case ReadCorporationStandings = 'esi-corporations.read_standings.v1';
     case ReadCorporationStarbases = 'esi-corporations.read_starbases.v1';
+    case ReadAgentsResearch = 'esi-characters.read_agents_research.v1';
+    case ReadCharacterBlueprints = 'esi-characters.read_blueprints.v1';
+    case ReadFatigue = 'esi-characters.read_fatigue.v1';
+    case ReadCharacterMedals = 'esi-characters.read_medals.v1';
+    case ReadNotifications = 'esi-characters.read_notifications.v1';
+    case ReadCharacterCorporationRoles = 'esi-characters.read_corporation_roles.v1';
+    case ReadCharacterStandings = 'esi-characters.read_standings.v1';
+    case ReadCharacterTitles = 'esi-characters.read_titles.v1';
 
     /**
      * @return array<int, string>

--- a/src/Esi.php
+++ b/src/Esi.php
@@ -6,6 +6,7 @@ declare(strict_types=1);
 
 namespace NicolasKion\Esi;
 
+use NicolasKion\Esi\DTO\AgentResearch;
 use NicolasKion\Esi\DTO\Alliance;
 use NicolasKion\Esi\DTO\AllianceHistory;
 use NicolasKion\Esi\DTO\AllianceIcons;
@@ -17,12 +18,18 @@ use NicolasKion\Esi\DTO\Bloodline;
 use NicolasKion\Esi\DTO\Blueprint;
 use NicolasKion\Esi\DTO\CharacterAffiliation;
 use NicolasKion\Esi\DTO\CharacterContract;
+use NicolasKion\Esi\DTO\CharacterMedal;
+use NicolasKion\Esi\DTO\CharacterPortrait;
+use NicolasKion\Esi\DTO\CharacterRoles;
+use NicolasKion\Esi\DTO\CharacterTitle;
 use NicolasKion\Esi\DTO\Constellation;
 use NicolasKion\Esi\DTO\Contact;
 use NicolasKion\Esi\DTO\ContactLabel;
+use NicolasKion\Esi\DTO\ContactNotification;
 use NicolasKion\Esi\DTO\ContainerLog;
 use NicolasKion\Esi\DTO\Corporation;
 use NicolasKion\Esi\DTO\CorporationDivisions;
+use NicolasKion\Esi\DTO\CorporationHistory;
 use NicolasKion\Esi\DTO\CorporationIcons;
 use NicolasKion\Esi\DTO\CorporationMedal;
 use NicolasKion\Esi\DTO\CorporationRoles;
@@ -37,6 +44,7 @@ use NicolasKion\Esi\DTO\Facility;
 use NicolasKion\Esi\DTO\Faction;
 use NicolasKion\Esi\DTO\Graphic;
 use NicolasKion\Esi\DTO\IssuedMedal;
+use NicolasKion\Esi\DTO\JumpFatigue;
 use NicolasKion\Esi\DTO\Killmail;
 use NicolasKion\Esi\DTO\Location;
 use NicolasKion\Esi\DTO\MarketGroup;
@@ -47,6 +55,7 @@ use NicolasKion\Esi\DTO\MemberTitles;
 use NicolasKion\Esi\DTO\MemberTracking;
 use NicolasKion\Esi\DTO\Moon;
 use NicolasKion\Esi\DTO\Name;
+use NicolasKion\Esi\DTO\Notification;
 use NicolasKion\Esi\DTO\Online;
 use NicolasKion\Esi\DTO\Planet;
 use NicolasKion\Esi\DTO\PublicContract;
@@ -84,6 +93,7 @@ use NicolasKion\Esi\Requests\AddCharacterContactsRequest;
 use NicolasKion\Esi\Requests\DeleteCharacterContactsRequest;
 use NicolasKion\Esi\Requests\EditCharacterContactsRequest;
 use NicolasKion\Esi\Requests\GetAffiliationsRequest;
+use NicolasKion\Esi\Requests\GetAgentsResearchRequest;
 use NicolasKion\Esi\Requests\GetAllianceContactLabelsRequest;
 use NicolasKion\Esi\Requests\GetAllianceContactsRequest;
 use NicolasKion\Esi\Requests\GetAllianceCorporationsRequest;
@@ -95,11 +105,21 @@ use NicolasKion\Esi\Requests\GetAssetNamesRequest;
 use NicolasKion\Esi\Requests\GetAssetsRequest;
 use NicolasKion\Esi\Requests\GetAsteroidBeltRequest;
 use NicolasKion\Esi\Requests\GetBloodlinesRequest;
+use NicolasKion\Esi\Requests\GetCharacterBlueprintsRequest;
 use NicolasKion\Esi\Requests\GetCharacterContactLabelsRequest;
+use NicolasKion\Esi\Requests\GetCharacterContactNotificationsRequest;
 use NicolasKion\Esi\Requests\GetCharacterContactsRequest;
 use NicolasKion\Esi\Requests\GetCharacterContractItemsRequest;
 use NicolasKion\Esi\Requests\GetCharacterContractsRequest;
+use NicolasKion\Esi\Requests\GetCharacterCorporationHistoryRequest;
+use NicolasKion\Esi\Requests\GetCharacterFatigueRequest;
+use NicolasKion\Esi\Requests\GetCharacterMedalsRequest;
+use NicolasKion\Esi\Requests\GetCharacterNotificationsRequest;
+use NicolasKion\Esi\Requests\GetCharacterPortraitRequest;
 use NicolasKion\Esi\Requests\GetCharacterRequest;
+use NicolasKion\Esi\Requests\GetCharacterRolesRequest;
+use NicolasKion\Esi\Requests\GetCharacterStandingsRequest;
+use NicolasKion\Esi\Requests\GetCharacterTitlesRequest;
 use NicolasKion\Esi\Requests\GetConstellationRequest;
 use NicolasKion\Esi\Requests\GetCorporationAllianceHistoryRequest;
 use NicolasKion\Esi\Requests\GetCorporationAssetNamesRequest;
@@ -126,6 +146,7 @@ use NicolasKion\Esi\Requests\GetCorporationStarbaseRequest;
 use NicolasKion\Esi\Requests\GetCorporationStarbasesRequest;
 use NicolasKion\Esi\Requests\GetCorporationStructuresRequest;
 use NicolasKion\Esi\Requests\GetCorporationTitlesRequest;
+use NicolasKion\Esi\Requests\GetCspaChargeRequest;
 use NicolasKion\Esi\Requests\GetDogmaAttributeRequest;
 use NicolasKion\Esi\Requests\GetDogmaAttributesRequest;
 use NicolasKion\Esi\Requests\GetDogmaEffectRequest;
@@ -1608,6 +1629,163 @@ class Esi
     {
         $connector = $this->getAuthenticatedConnector($character, EsiScope::ReadCorporationTitles);
         $request = new GetCorporationTitlesRequest($corporation_id);
+
+        return $connector->send($request);
+    }
+
+    /**
+     * Retrieves the corporation history of a character.
+     *
+     * @return EsiResult<array<int, CorporationHistory>>
+     */
+    public function getCharacterCorporationHistory(int $character_id): EsiResult
+    {
+        $connector = new Connector;
+        $request = new GetCharacterCorporationHistoryRequest($character_id);
+
+        return $connector->send($request);
+    }
+
+    /**
+     * Retrieves the portrait URLs of a character.
+     *
+     * @return EsiResult<CharacterPortrait>
+     */
+    public function getCharacterPortrait(int $character_id): EsiResult
+    {
+        $connector = new Connector;
+        $request = new GetCharacterPortraitRequest($character_id);
+
+        return $connector->send($request);
+    }
+
+    /**
+     * Retrieves a character's agents research progress.
+     *
+     * @return EsiResult<array<int, AgentResearch>>
+     */
+    public function getAgentsResearch(Character $character): EsiResult
+    {
+        $connector = $this->getAuthenticatedConnector($character, EsiScope::ReadAgentsResearch);
+        $request = new GetAgentsResearchRequest($character->getId());
+
+        return $connector->send($request);
+    }
+
+    /**
+     * Retrieves the blueprints owned by a character.
+     *
+     * @return EsiResult<array<int, Blueprint>>
+     */
+    public function getCharacterBlueprints(Character $character): EsiResult
+    {
+        $connector = $this->getAuthenticatedConnector($character, EsiScope::ReadCharacterBlueprints);
+        $request = new GetCharacterBlueprintsRequest($character->getId());
+
+        return $connector->sendPaginated($request);
+    }
+
+    /**
+     * Retrieves a character's jump fatigue.
+     *
+     * @return EsiResult<JumpFatigue>
+     */
+    public function getCharacterFatigue(Character $character): EsiResult
+    {
+        $connector = $this->getAuthenticatedConnector($character, EsiScope::ReadFatigue);
+        $request = new GetCharacterFatigueRequest($character->getId());
+
+        return $connector->send($request);
+    }
+
+    /**
+     * Retrieves the medals of a character.
+     *
+     * @return EsiResult<array<int, CharacterMedal>>
+     */
+    public function getCharacterMedals(Character $character): EsiResult
+    {
+        $connector = $this->getAuthenticatedConnector($character, EsiScope::ReadCharacterMedals);
+        $request = new GetCharacterMedalsRequest($character->getId());
+
+        return $connector->send($request);
+    }
+
+    /**
+     * Retrieves the notifications of a character.
+     *
+     * @return EsiResult<array<int, Notification>>
+     */
+    public function getCharacterNotifications(Character $character): EsiResult
+    {
+        $connector = $this->getAuthenticatedConnector($character, EsiScope::ReadNotifications);
+        $request = new GetCharacterNotificationsRequest($character->getId());
+
+        return $connector->send($request);
+    }
+
+    /**
+     * Retrieves the contact notifications of a character.
+     *
+     * @return EsiResult<array<int, ContactNotification>>
+     */
+    public function getCharacterContactNotifications(Character $character): EsiResult
+    {
+        $connector = $this->getAuthenticatedConnector($character, EsiScope::ReadNotifications);
+        $request = new GetCharacterContactNotificationsRequest($character->getId());
+
+        return $connector->send($request);
+    }
+
+    /**
+     * Retrieves the corporation roles of a character.
+     *
+     * @return EsiResult<CharacterRoles>
+     */
+    public function getCharacterRoles(Character $character): EsiResult
+    {
+        $connector = $this->getAuthenticatedConnector($character, EsiScope::ReadCharacterCorporationRoles);
+        $request = new GetCharacterRolesRequest($character->getId());
+
+        return $connector->send($request);
+    }
+
+    /**
+     * Retrieves the standings of a character.
+     *
+     * @return EsiResult<array<int, Standing>>
+     */
+    public function getCharacterStandings(Character $character): EsiResult
+    {
+        $connector = $this->getAuthenticatedConnector($character, EsiScope::ReadCharacterStandings);
+        $request = new GetCharacterStandingsRequest($character->getId());
+
+        return $connector->send($request);
+    }
+
+    /**
+     * Retrieves the titles of a character.
+     *
+     * @return EsiResult<array<int, CharacterTitle>>
+     */
+    public function getCharacterTitles(Character $character): EsiResult
+    {
+        $connector = $this->getAuthenticatedConnector($character, EsiScope::ReadCharacterTitles);
+        $request = new GetCharacterTitlesRequest($character->getId());
+
+        return $connector->send($request);
+    }
+
+    /**
+     * Calculates the CSPA charge cost for contacting a set of characters.
+     *
+     * @param  array<int, int>  $character_ids
+     * @return EsiResult<float>
+     */
+    public function getCspaCharge(Character $character, array $character_ids): EsiResult
+    {
+        $connector = $this->getAuthenticatedConnector($character, EsiScope::ReadCharacterContacts);
+        $request = new GetCspaChargeRequest($character->getId(), $character_ids);
 
         return $connector->send($request);
     }

--- a/src/Requests/GetAgentsResearchRequest.php
+++ b/src/Requests/GetAgentsResearchRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\Requests;
+
+use Illuminate\Http\Client\Response;
+use NicolasKion\Esi\DTO\AgentResearch;
+use NicolasKion\Esi\Request;
+
+/**
+ * @extends Request<array<int, AgentResearch>>
+ */
+class GetAgentsResearchRequest extends Request
+{
+    public function __construct(public int $character_id) {}
+
+    public function resolveEndpoint(): string
+    {
+        return sprintf('/characters/%d/agents_research/', $this->character_id);
+    }
+
+    /**
+     * @return array<int, AgentResearch>
+     */
+    public function createDto(Response $response, mixed $data): array
+    {
+        return AgentResearch::hydrateList($data);
+    }
+}

--- a/src/Requests/GetCharacterBlueprintsRequest.php
+++ b/src/Requests/GetCharacterBlueprintsRequest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\Requests;
+
+use Illuminate\Http\Client\Response;
+use NicolasKion\Esi\DTO\Blueprint;
+use NicolasKion\Esi\Interfaces\WithPagination;
+use NicolasKion\Esi\Request;
+use NicolasKion\Esi\Traits\BasicPagination;
+
+/**
+ * @extends Request<array<int, Blueprint>>
+ *
+ * @implements WithPagination<array<int, Blueprint>>
+ */
+class GetCharacterBlueprintsRequest extends Request implements WithPagination
+{
+    use BasicPagination;
+
+    public function __construct(public int $character_id) {}
+
+    public function resolveEndpoint(): string
+    {
+        return sprintf('/characters/%d/blueprints/', $this->character_id);
+    }
+
+    /**
+     * @return array<int, Blueprint>
+     */
+    public function createDto(Response $response, mixed $data): array
+    {
+        return Blueprint::hydrateList($data);
+    }
+}

--- a/src/Requests/GetCharacterContactNotificationsRequest.php
+++ b/src/Requests/GetCharacterContactNotificationsRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\Requests;
+
+use Illuminate\Http\Client\Response;
+use NicolasKion\Esi\DTO\ContactNotification;
+use NicolasKion\Esi\Request;
+
+/**
+ * @extends Request<array<int, ContactNotification>>
+ */
+class GetCharacterContactNotificationsRequest extends Request
+{
+    public function __construct(public int $character_id) {}
+
+    public function resolveEndpoint(): string
+    {
+        return sprintf('/characters/%d/notifications/contacts/', $this->character_id);
+    }
+
+    /**
+     * @return array<int, ContactNotification>
+     */
+    public function createDto(Response $response, mixed $data): array
+    {
+        return ContactNotification::hydrateList($data);
+    }
+}

--- a/src/Requests/GetCharacterCorporationHistoryRequest.php
+++ b/src/Requests/GetCharacterCorporationHistoryRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\Requests;
+
+use Illuminate\Http\Client\Response;
+use NicolasKion\Esi\DTO\CorporationHistory;
+use NicolasKion\Esi\Request;
+
+/**
+ * @extends Request<array<int, CorporationHistory>>
+ */
+class GetCharacterCorporationHistoryRequest extends Request
+{
+    public function __construct(public int $character_id) {}
+
+    public function resolveEndpoint(): string
+    {
+        return sprintf('/characters/%d/corporationhistory/', $this->character_id);
+    }
+
+    /**
+     * @return array<int, CorporationHistory>
+     */
+    public function createDto(Response $response, mixed $data): array
+    {
+        return CorporationHistory::hydrateList($data);
+    }
+}

--- a/src/Requests/GetCharacterFatigueRequest.php
+++ b/src/Requests/GetCharacterFatigueRequest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\Requests;
+
+use Illuminate\Http\Client\Response;
+use NicolasKion\Esi\DTO\JumpFatigue;
+use NicolasKion\Esi\Request;
+
+/**
+ * @extends Request<JumpFatigue>
+ */
+class GetCharacterFatigueRequest extends Request
+{
+    public function __construct(public int $character_id) {}
+
+    public function resolveEndpoint(): string
+    {
+        return sprintf('/characters/%d/fatigue/', $this->character_id);
+    }
+
+    public function createDto(Response $response, mixed $data): JumpFatigue
+    {
+        return JumpFatigue::hydrate($data);
+    }
+}

--- a/src/Requests/GetCharacterMedalsRequest.php
+++ b/src/Requests/GetCharacterMedalsRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\Requests;
+
+use Illuminate\Http\Client\Response;
+use NicolasKion\Esi\DTO\CharacterMedal;
+use NicolasKion\Esi\Request;
+
+/**
+ * @extends Request<array<int, CharacterMedal>>
+ */
+class GetCharacterMedalsRequest extends Request
+{
+    public function __construct(public int $character_id) {}
+
+    public function resolveEndpoint(): string
+    {
+        return sprintf('/characters/%d/medals/', $this->character_id);
+    }
+
+    /**
+     * @return array<int, CharacterMedal>
+     */
+    public function createDto(Response $response, mixed $data): array
+    {
+        return CharacterMedal::hydrateList($data);
+    }
+}

--- a/src/Requests/GetCharacterNotificationsRequest.php
+++ b/src/Requests/GetCharacterNotificationsRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\Requests;
+
+use Illuminate\Http\Client\Response;
+use NicolasKion\Esi\DTO\Notification;
+use NicolasKion\Esi\Request;
+
+/**
+ * @extends Request<array<int, Notification>>
+ */
+class GetCharacterNotificationsRequest extends Request
+{
+    public function __construct(public int $character_id) {}
+
+    public function resolveEndpoint(): string
+    {
+        return sprintf('/characters/%d/notifications/', $this->character_id);
+    }
+
+    /**
+     * @return array<int, Notification>
+     */
+    public function createDto(Response $response, mixed $data): array
+    {
+        return Notification::hydrateList($data);
+    }
+}

--- a/src/Requests/GetCharacterPortraitRequest.php
+++ b/src/Requests/GetCharacterPortraitRequest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\Requests;
+
+use Illuminate\Http\Client\Response;
+use NicolasKion\Esi\DTO\CharacterPortrait;
+use NicolasKion\Esi\Request;
+
+/**
+ * @extends Request<CharacterPortrait>
+ */
+class GetCharacterPortraitRequest extends Request
+{
+    public function __construct(public int $character_id) {}
+
+    public function resolveEndpoint(): string
+    {
+        return sprintf('/characters/%d/portrait/', $this->character_id);
+    }
+
+    public function createDto(Response $response, mixed $data): CharacterPortrait
+    {
+        return CharacterPortrait::hydrate($data);
+    }
+}

--- a/src/Requests/GetCharacterRolesRequest.php
+++ b/src/Requests/GetCharacterRolesRequest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\Requests;
+
+use Illuminate\Http\Client\Response;
+use NicolasKion\Esi\DTO\CharacterRoles;
+use NicolasKion\Esi\Request;
+
+/**
+ * @extends Request<CharacterRoles>
+ */
+class GetCharacterRolesRequest extends Request
+{
+    public function __construct(public int $character_id) {}
+
+    public function resolveEndpoint(): string
+    {
+        return sprintf('/characters/%d/roles/', $this->character_id);
+    }
+
+    public function createDto(Response $response, mixed $data): CharacterRoles
+    {
+        return CharacterRoles::hydrate($data);
+    }
+}

--- a/src/Requests/GetCharacterStandingsRequest.php
+++ b/src/Requests/GetCharacterStandingsRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\Requests;
+
+use Illuminate\Http\Client\Response;
+use NicolasKion\Esi\DTO\Standing;
+use NicolasKion\Esi\Request;
+
+/**
+ * @extends Request<array<int, Standing>>
+ */
+class GetCharacterStandingsRequest extends Request
+{
+    public function __construct(public int $character_id) {}
+
+    public function resolveEndpoint(): string
+    {
+        return sprintf('/characters/%d/standings/', $this->character_id);
+    }
+
+    /**
+     * @return array<int, Standing>
+     */
+    public function createDto(Response $response, mixed $data): array
+    {
+        return Standing::hydrateList($data);
+    }
+}

--- a/src/Requests/GetCharacterTitlesRequest.php
+++ b/src/Requests/GetCharacterTitlesRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\Requests;
+
+use Illuminate\Http\Client\Response;
+use NicolasKion\Esi\DTO\CharacterTitle;
+use NicolasKion\Esi\Request;
+
+/**
+ * @extends Request<array<int, CharacterTitle>>
+ */
+class GetCharacterTitlesRequest extends Request
+{
+    public function __construct(public int $character_id) {}
+
+    public function resolveEndpoint(): string
+    {
+        return sprintf('/characters/%d/titles/', $this->character_id);
+    }
+
+    /**
+     * @return array<int, CharacterTitle>
+     */
+    public function createDto(Response $response, mixed $data): array
+    {
+        return CharacterTitle::hydrateList($data);
+    }
+}

--- a/src/Requests/GetCspaChargeRequest.php
+++ b/src/Requests/GetCspaChargeRequest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\Requests;
+
+use Illuminate\Http\Client\Response;
+use NicolasKion\Esi\Enums\RequestMethod;
+use NicolasKion\Esi\Interfaces\WithBody;
+use NicolasKion\Esi\Request;
+
+/**
+ * @extends Request<float>
+ */
+class GetCspaChargeRequest extends Request implements WithBody
+{
+    /**
+     * @param  array<int, int>  $character_ids
+     */
+    public function __construct(public int $character_id, public array $character_ids) {}
+
+    /**
+     * @return array<int, int>
+     */
+    public function getBody(): array
+    {
+        return $this->character_ids;
+    }
+
+    public function resolveEndpoint(): string
+    {
+        return sprintf('/characters/%d/cspa/', $this->character_id);
+    }
+
+    public function getMethod(): RequestMethod
+    {
+        return RequestMethod::POST;
+    }
+
+    public function createDto(Response $response, mixed $data): float
+    {
+        return is_numeric($data) ? (float) $data : 0.0;
+    }
+}

--- a/tests/CharacterExtraTest.php
+++ b/tests/CharacterExtraTest.php
@@ -1,0 +1,330 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Http;
+use NicolasKion\Esi\DTO\AgentResearch;
+use NicolasKion\Esi\DTO\Blueprint;
+use NicolasKion\Esi\DTO\CharacterMedal;
+use NicolasKion\Esi\DTO\CharacterPortrait;
+use NicolasKion\Esi\DTO\CharacterRoles;
+use NicolasKion\Esi\DTO\CharacterTitle;
+use NicolasKion\Esi\DTO\ContactNotification;
+use NicolasKion\Esi\DTO\CorporationHistory;
+use NicolasKion\Esi\DTO\JumpFatigue;
+use NicolasKion\Esi\DTO\Notification;
+use NicolasKion\Esi\DTO\Standing;
+use NicolasKion\Esi\Esi;
+
+it('fetches and maps a character corporation history', function (): void {
+    Http::fake([
+        'esi.evetech.net/characters/90000001/corporationhistory/' => Http::response([
+            [
+                'corporation_id' => 98777771,
+                'is_deleted' => true,
+                'record_id' => 1,
+                'start_date' => '2026-06-09T12:00:00Z',
+            ],
+            [
+                // A sparse entry: is_deleted is absent.
+                'corporation_id' => 98777772,
+                'record_id' => 2,
+                'start_date' => '2026-05-09T12:00:00Z',
+            ],
+        ]),
+    ]);
+
+    $result = (new Esi)->getCharacterCorporationHistory(90000001);
+
+    expect($result->wasSuccessful())->toBeTrue()
+        ->and($result->data)->toHaveCount(2)
+        ->and($result->data[0])->toBeInstanceOf(CorporationHistory::class)
+        ->and($result->data[0]->corporation_id)->toBe(98777771)
+        ->and($result->data[0]->is_deleted)->toBeTrue()
+        ->and($result->data[0]->record_id)->toBe(1)
+        ->and($result->data[0]->start_date)->toBe('2026-06-09T12:00:00Z')
+        ->and($result->data[1]->is_deleted)->toBeNull();
+});
+
+it('fetches and maps a character portrait', function (): void {
+    Http::fake([
+        'esi.evetech.net/characters/90000001/portrait/' => Http::response(esiFixture('characters/portrait.json')),
+    ]);
+
+    $result = (new Esi)->getCharacterPortrait(90000001);
+
+    expect($result->wasSuccessful())->toBeTrue()
+        ->and($result->data)->toBeInstanceOf(CharacterPortrait::class)
+        ->and($result->data->px128x128)->toBe('string')
+        ->and($result->data->px256x256)->toBe('string')
+        ->and($result->data->px512x512)->toBe('string')
+        ->and($result->data->px64x64)->toBe('string');
+});
+
+it('fetches and maps a character agents research', function (): void {
+    Http::fake([
+        'esi.evetech.net/characters/123/agents_research/' => Http::response([
+            [
+                'agent_id' => 1,
+                'points_per_day' => 1.5,
+                'remainder_points' => 2.5,
+                'skill_type_id' => 3,
+                'started_at' => '2026-06-09T12:00:00Z',
+            ],
+        ]),
+    ]);
+
+    $result = (new Esi)->getAgentsResearch(fakeCharacter());
+
+    expect($result->wasSuccessful())->toBeTrue()
+        ->and($result->data)->toHaveCount(1)
+        ->and($result->data[0])->toBeInstanceOf(AgentResearch::class)
+        ->and($result->data[0]->agent_id)->toBe(1)
+        ->and($result->data[0]->points_per_day)->toBe(1.5)
+        ->and($result->data[0]->remainder_points)->toBe(2.5)
+        ->and($result->data[0]->skill_type_id)->toBe(3)
+        ->and($result->data[0]->started_at)->toBe('2026-06-09T12:00:00Z');
+});
+
+it('fetches and maps paginated character blueprints, reusing the corporation Blueprint DTO', function (): void {
+    Http::fake([
+        'esi.evetech.net/characters/123/blueprints/*' => Http::response([
+            [
+                'item_id' => 1,
+                'location_flag' => 'AssetSafety',
+                'location_id' => 2,
+                'material_efficiency' => 3,
+                'quantity' => 4,
+                'runs' => 5,
+                'time_efficiency' => 6,
+                'type_id' => 7,
+            ],
+        ], 200, ['X-Pages' => '1']),
+    ]);
+
+    $result = (new Esi)->getCharacterBlueprints(fakeCharacter());
+
+    expect($result->wasSuccessful())->toBeTrue()
+        ->and($result->data)->toHaveCount(1)
+        ->and($result->data[0])->toBeInstanceOf(Blueprint::class)
+        ->and($result->data[0]->item_id)->toBe(1)
+        ->and($result->data[0]->location_flag)->toBe('AssetSafety')
+        ->and($result->data[0]->location_id)->toBe(2)
+        ->and($result->data[0]->material_efficiency)->toBe(3)
+        ->and($result->data[0]->quantity)->toBe(4)
+        ->and($result->data[0]->runs)->toBe(5)
+        ->and($result->data[0]->time_efficiency)->toBe(6)
+        ->and($result->data[0]->type_id)->toBe(7);
+});
+
+it('fetches and maps a character jump fatigue', function (): void {
+    Http::fake([
+        'esi.evetech.net/characters/123/fatigue/' => Http::response(esiFixture('characters/fatigue.json')),
+    ]);
+
+    $result = (new Esi)->getCharacterFatigue(fakeCharacter());
+
+    expect($result->wasSuccessful())->toBeTrue()
+        ->and($result->data)->toBeInstanceOf(JumpFatigue::class)
+        ->and($result->data->jump_fatigue_expire_date)->toBe('2026-06-09T12:00:00Z')
+        ->and($result->data->last_jump_date)->toBe('2026-06-09T12:00:00Z')
+        ->and($result->data->last_update_date)->toBe('2026-06-09T12:00:00Z');
+});
+
+it('fetches and maps character medals', function (): void {
+    Http::fake([
+        'esi.evetech.net/characters/123/medals/' => Http::response([
+            [
+                'corporation_id' => 1,
+                'date' => '2026-06-09T12:00:00Z',
+                'description' => 'string',
+                'graphics' => [
+                    ['color' => 1, 'graphic' => 'string', 'layer' => 2, 'part' => 3],
+                ],
+                'issuer_id' => 4,
+                'medal_id' => 5,
+                'reason' => 'string',
+                'status' => 'public',
+                'title' => 'string',
+            ],
+        ]),
+    ]);
+
+    $result = (new Esi)->getCharacterMedals(fakeCharacter());
+
+    expect($result->wasSuccessful())->toBeTrue()
+        ->and($result->data)->toHaveCount(1)
+        ->and($result->data[0])->toBeInstanceOf(CharacterMedal::class)
+        ->and($result->data[0]->corporation_id)->toBe(1)
+        ->and($result->data[0]->date)->toBe('2026-06-09T12:00:00Z')
+        ->and($result->data[0]->description)->toBe('string')
+        ->and($result->data[0]->graphics)->toHaveCount(1)
+        ->and($result->data[0]->graphics[0]->color)->toBe(1)
+        ->and($result->data[0]->graphics[0]->graphic)->toBe('string')
+        ->and($result->data[0]->graphics[0]->layer)->toBe(2)
+        ->and($result->data[0]->graphics[0]->part)->toBe(3)
+        ->and($result->data[0]->issuer_id)->toBe(4)
+        ->and($result->data[0]->medal_id)->toBe(5)
+        ->and($result->data[0]->reason)->toBe('string')
+        ->and($result->data[0]->status)->toBe('public')
+        ->and($result->data[0]->title)->toBe('string');
+});
+
+it('fetches and maps character notifications', function (): void {
+    Http::fake([
+        'esi.evetech.net/characters/123/notifications/' => Http::response([
+            [
+                'is_read' => true,
+                'notification_id' => 1,
+                'sender_id' => 2,
+                'sender_type' => 'character',
+                'text' => 'string',
+                'timestamp' => '2026-06-09T12:00:00Z',
+                'type' => 'AcceptedAlly',
+            ],
+            [
+                // A sparse entry: is_read and text are absent.
+                'notification_id' => 3,
+                'sender_id' => 4,
+                'sender_type' => 'corporation',
+                'timestamp' => '2026-06-10T12:00:00Z',
+                'type' => 'CorpNewsMsg',
+            ],
+        ]),
+    ]);
+
+    $result = (new Esi)->getCharacterNotifications(fakeCharacter());
+
+    expect($result->wasSuccessful())->toBeTrue()
+        ->and($result->data)->toHaveCount(2)
+        ->and($result->data[0])->toBeInstanceOf(Notification::class)
+        ->and($result->data[0]->is_read)->toBeTrue()
+        ->and($result->data[0]->notification_id)->toBe(1)
+        ->and($result->data[0]->sender_id)->toBe(2)
+        ->and($result->data[0]->sender_type)->toBe('character')
+        ->and($result->data[0]->text)->toBe('string')
+        ->and($result->data[0]->timestamp)->toBe('2026-06-09T12:00:00Z')
+        ->and($result->data[0]->type)->toBe('AcceptedAlly')
+        ->and($result->data[1]->is_read)->toBeNull()
+        ->and($result->data[1]->text)->toBeNull();
+});
+
+it('fetches and maps character contact notifications', function (): void {
+    Http::fake([
+        'esi.evetech.net/characters/123/notifications/contacts/' => Http::response([
+            [
+                'message' => 'string',
+                'notification_id' => 1,
+                'send_date' => '2026-06-09T12:00:00Z',
+                'sender_character_id' => 2,
+                'standing_level' => 5.0,
+            ],
+        ]),
+    ]);
+
+    $result = (new Esi)->getCharacterContactNotifications(fakeCharacter());
+
+    expect($result->wasSuccessful())->toBeTrue()
+        ->and($result->data)->toHaveCount(1)
+        ->and($result->data[0])->toBeInstanceOf(ContactNotification::class)
+        ->and($result->data[0]->message)->toBe('string')
+        ->and($result->data[0]->notification_id)->toBe(1)
+        ->and($result->data[0]->send_date)->toBe('2026-06-09T12:00:00Z')
+        ->and($result->data[0]->sender_character_id)->toBe(2)
+        ->and($result->data[0]->standing_level)->toBe(5.0);
+});
+
+it('fetches and maps character corporation roles', function (): void {
+    Http::fake([
+        'esi.evetech.net/characters/123/roles/' => Http::response(esiFixture('characters/roles.json')),
+    ]);
+
+    $result = (new Esi)->getCharacterRoles(fakeCharacter());
+
+    expect($result->wasSuccessful())->toBeTrue()
+        ->and($result->data)->toBeInstanceOf(CharacterRoles::class)
+        ->and($result->data->roles)->toBe(['Account_Take_1'])
+        ->and($result->data->roles_at_base)->toBe(['Account_Take_1'])
+        ->and($result->data->roles_at_hq)->toBe(['Account_Take_1'])
+        ->and($result->data->roles_at_other)->toBe(['Account_Take_1']);
+});
+
+it('fetches and maps character corporation roles with sparse role arrays', function (): void {
+    Http::fake([
+        'esi.evetech.net/characters/123/roles/' => Http::response([
+            'roles' => ['Director', 456],
+        ]),
+    ]);
+
+    $result = (new Esi)->getCharacterRoles(fakeCharacter());
+
+    expect($result->wasSuccessful())->toBeTrue()
+        ->and($result->data->roles)->toBe(['Director', ''])
+        ->and($result->data->roles_at_base)->toBe([])
+        ->and($result->data->roles_at_hq)->toBe([])
+        ->and($result->data->roles_at_other)->toBe([]);
+});
+
+it('fetches and maps character standings, reusing the corporation Standing DTO', function (): void {
+    Http::fake([
+        'esi.evetech.net/characters/123/standings/' => Http::response([
+            ['from_id' => 90000001, 'from_type' => 'agent', 'standing' => 1.5],
+        ]),
+    ]);
+
+    $result = (new Esi)->getCharacterStandings(fakeCharacter());
+
+    expect($result->wasSuccessful())->toBeTrue()
+        ->and($result->data)->toHaveCount(1)
+        ->and($result->data[0])->toBeInstanceOf(Standing::class)
+        ->and($result->data[0]->from_id)->toBe(90000001)
+        ->and($result->data[0]->from_type)->toBe('agent')
+        ->and($result->data[0]->standing)->toBe(1.5);
+});
+
+it('fetches and maps character titles', function (): void {
+    Http::fake([
+        'esi.evetech.net/characters/123/titles/' => Http::response([
+            ['name' => 'string', 'title_id' => 1],
+            [
+                // A sparse entry: name and title_id are both absent.
+            ],
+        ]),
+    ]);
+
+    $result = (new Esi)->getCharacterTitles(fakeCharacter());
+
+    expect($result->wasSuccessful())->toBeTrue()
+        ->and($result->data)->toHaveCount(2)
+        ->and($result->data[0])->toBeInstanceOf(CharacterTitle::class)
+        ->and($result->data[0]->name)->toBe('string')
+        ->and($result->data[0]->title_id)->toBe(1)
+        ->and($result->data[1]->name)->toBeNull()
+        ->and($result->data[1]->title_id)->toBeNull();
+});
+
+it('calculates the cspa charge cost for a set of characters', function (): void {
+    Http::fake([
+        'esi.evetech.net/characters/123/cspa/' => Http::response('150.5', 201, ['Content-Type' => 'application/json']),
+    ]);
+
+    $result = (new Esi)->getCspaCharge(fakeCharacter(), [90000001, 90000002]);
+
+    expect($result->wasSuccessful())->toBeTrue()
+        ->and($result->data)->toBe(150.5);
+
+    Http::assertSent(fn ($request) => $request->method() === 'POST'
+        && str_contains($request->url(), '/characters/123/cspa/')
+        && $request->data() === [90000001, 90000002]);
+});
+
+it('returns an error result when a character endpoint fails with a server error', function (): void {
+    Http::fake([
+        'esi.evetech.net/characters/123/medals/' => Http::response(['error' => 'Internal server error'], 500),
+    ]);
+
+    $result = (new Esi)->getCharacterMedals(fakeCharacter());
+
+    expect($result->failed())->toBeTrue()
+        ->and($result->error?->code)->toBe(500);
+});

--- a/tests/Fixtures/characters/fatigue.json
+++ b/tests/Fixtures/characters/fatigue.json
@@ -1,0 +1,5 @@
+{
+    "jump_fatigue_expire_date": "2026-06-09T12:00:00Z",
+    "last_jump_date": "2026-06-09T12:00:00Z",
+    "last_update_date": "2026-06-09T12:00:00Z"
+}

--- a/tests/Fixtures/characters/portrait.json
+++ b/tests/Fixtures/characters/portrait.json
@@ -1,0 +1,6 @@
+{
+    "px128x128": "string",
+    "px256x256": "string",
+    "px512x512": "string",
+    "px64x64": "string"
+}

--- a/tests/Fixtures/characters/roles.json
+++ b/tests/Fixtures/characters/roles.json
@@ -1,0 +1,14 @@
+{
+    "roles": [
+        "Account_Take_1"
+    ],
+    "roles_at_base": [
+        "Account_Take_1"
+    ],
+    "roles_at_hq": [
+        "Account_Take_1"
+    ],
+    "roles_at_other": [
+        "Account_Take_1"
+    ]
+}


### PR DESCRIPTION
Completes the Character domain (12 endpoints): public corporation-history/portrait and authenticated agents-research/blueprints/fatigue/medals/notifications/roles/standings/titles/cspa. 10 DTOs (+ reused Blueprint/Standing), 12 requests, 8 scopes. PHPStan level 9 clean, 100% coverage (172 tests).