### PR TITLE
feat: add skills and clones endpoints

### DIFF
--- a/src/DTO/CharacterAttributes.php
+++ b/src/DTO/CharacterAttributes.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\DTO;
+
+use NicolasKion\Esi\Support\Data;
+
+readonly class CharacterAttributes extends Dto
+{
+    public function __construct(
+        public int $charisma,
+        public int $intelligence,
+        public int $memory,
+        public int $perception,
+        public int $willpower,
+        public ?string $accrued_remap_cooldown_date,
+        public ?int $bonus_remaps,
+        public ?string $last_remap_date,
+    ) {}
+
+    public static function fromData(Data $data): self
+    {
+        return new self(
+            charisma: $data->integer('charisma', 0),
+            intelligence: $data->integer('intelligence', 0),
+            memory: $data->integer('memory', 0),
+            perception: $data->integer('perception', 0),
+            willpower: $data->integer('willpower', 0),
+            accrued_remap_cooldown_date: $data->string('accrued_remap_cooldown_date'),
+            bonus_remaps: $data->integer('bonus_remaps'),
+            last_remap_date: $data->string('last_remap_date'),
+        );
+    }
+}

--- a/src/DTO/CharacterClones.php
+++ b/src/DTO/CharacterClones.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\DTO;
+
+use NicolasKion\Esi\Support\Data;
+
+readonly class CharacterClones extends Dto
+{
+    /**
+     * @param  array<int, JumpClone>  $jump_clones
+     */
+    public function __construct(
+        public CloneHomeLocation $home_location,
+        public array $jump_clones,
+        public ?string $last_clone_jump_date,
+        public ?string $last_station_change_date,
+    ) {}
+
+    public static function fromData(Data $data): self
+    {
+        return new self(
+            home_location: CloneHomeLocation::fromData($data->object('home_location')),
+            jump_clones: $data->list('jump_clones', JumpClone::fromData(...)),
+            last_clone_jump_date: $data->string('last_clone_jump_date'),
+            last_station_change_date: $data->string('last_station_change_date'),
+        );
+    }
+}

--- a/src/DTO/CharacterSkills.php
+++ b/src/DTO/CharacterSkills.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\DTO;
+
+use NicolasKion\Esi\Support\Data;
+
+readonly class CharacterSkills extends Dto
+{
+    /**
+     * @param  array<int, Skill>  $skills
+     */
+    public function __construct(
+        public array $skills,
+        public int $total_sp,
+        public ?int $unallocated_sp,
+    ) {}
+
+    public static function fromData(Data $data): self
+    {
+        return new self(
+            skills: $data->list('skills', Skill::fromData(...)),
+            total_sp: $data->integer('total_sp', 0),
+            unallocated_sp: $data->integer('unallocated_sp'),
+        );
+    }
+}

--- a/src/DTO/CloneHomeLocation.php
+++ b/src/DTO/CloneHomeLocation.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\DTO;
+
+use NicolasKion\Esi\Support\Data;
+
+readonly class CloneHomeLocation extends Dto
+{
+    public function __construct(
+        public ?int $location_id,
+        public ?string $location_type,
+    ) {}
+
+    public static function fromData(Data $data): self
+    {
+        return new self(
+            location_id: $data->integer('location_id'),
+            location_type: $data->string('location_type'),
+        );
+    }
+}

--- a/src/DTO/JumpClone.php
+++ b/src/DTO/JumpClone.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\DTO;
+
+use NicolasKion\Esi\Support\Data;
+
+readonly class JumpClone extends Dto
+{
+    /**
+     * @param  array<int, int>  $implants
+     */
+    public function __construct(
+        public int $jump_clone_id,
+        public int $location_id,
+        public string $location_type,
+        public array $implants,
+        public ?string $name,
+    ) {}
+
+    public static function fromData(Data $data): self
+    {
+        return new self(
+            jump_clone_id: $data->integer('jump_clone_id', 0),
+            location_id: $data->integer('location_id', 0),
+            location_type: $data->string('location_type', ''),
+            implants: $data->integers('implants'),
+            name: $data->string('name'),
+        );
+    }
+}

--- a/src/DTO/Skill.php
+++ b/src/DTO/Skill.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\DTO;
+
+use NicolasKion\Esi\Support\Data;
+
+readonly class Skill extends Dto
+{
+    public function __construct(
+        public int $skill_id,
+        public int $active_skill_level,
+        public int $skillpoints_in_skill,
+        public int $trained_skill_level,
+    ) {}
+
+    public static function fromData(Data $data): self
+    {
+        return new self(
+            skill_id: $data->integer('skill_id', 0),
+            active_skill_level: $data->integer('active_skill_level', 0),
+            skillpoints_in_skill: $data->integer('skillpoints_in_skill', 0),
+            trained_skill_level: $data->integer('trained_skill_level', 0),
+        );
+    }
+}

--- a/src/DTO/SkillQueueEntry.php
+++ b/src/DTO/SkillQueueEntry.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\DTO;
+
+use NicolasKion\Esi\Support\Data;
+
+readonly class SkillQueueEntry extends Dto
+{
+    public function __construct(
+        public int $skill_id,
+        public int $finished_level,
+        public int $queue_position,
+        public ?string $finish_date,
+        public ?int $level_end_sp,
+        public ?int $level_start_sp,
+        public ?string $start_date,
+        public ?int $training_start_sp,
+    ) {}
+
+    public static function fromData(Data $data): self
+    {
+        return new self(
+            skill_id: $data->integer('skill_id', 0),
+            finished_level: $data->integer('finished_level', 0),
+            queue_position: $data->integer('queue_position', 0),
+            finish_date: $data->string('finish_date'),
+            level_end_sp: $data->integer('level_end_sp'),
+            level_start_sp: $data->integer('level_start_sp'),
+            start_date: $data->string('start_date'),
+            training_start_sp: $data->integer('training_start_sp'),
+        );
+    }
+}

--- a/src/Enums/EsiScope.php
+++ b/src/Enums/EsiScope.php
@@ -47,6 +47,10 @@ enum EsiScope: string
     case ReadCharacterTitles = 'esi-characters.read_titles.v1';
     case ReadCharacterFwStats = 'esi-characters.read_fw_stats.v1';
     case ReadCorporationFwStats = 'esi-corporations.read_fw_stats.v1';
+    case ReadSkills = 'esi-skills.read_skills.v1';
+    case ReadSkillQueue = 'esi-skills.read_skillqueue.v1';
+    case ReadClones = 'esi-clones.read_clones.v1';
+    case ReadImplants = 'esi-clones.read_implants.v1';
 
     /**
      * @return array<int, string>

--- a/src/Esi.php
+++ b/src/Esi.php
@@ -17,11 +17,14 @@ use NicolasKion\Esi\DTO\AsteroidBelt;
 use NicolasKion\Esi\DTO\Bloodline;
 use NicolasKion\Esi\DTO\Blueprint;
 use NicolasKion\Esi\DTO\CharacterAffiliation;
+use NicolasKion\Esi\DTO\CharacterAttributes;
+use NicolasKion\Esi\DTO\CharacterClones;
 use NicolasKion\Esi\DTO\CharacterContract;
 use NicolasKion\Esi\DTO\CharacterFactionWarfareStats;
 use NicolasKion\Esi\DTO\CharacterMedal;
 use NicolasKion\Esi\DTO\CharacterPortrait;
 use NicolasKion\Esi\DTO\CharacterRoles;
+use NicolasKion\Esi\DTO\CharacterSkills;
 use NicolasKion\Esi\DTO\CharacterTitle;
 use NicolasKion\Esi\DTO\Constellation;
 use NicolasKion\Esi\DTO\Contact;
@@ -80,6 +83,7 @@ use NicolasKion\Esi\DTO\RoleHistory;
 use NicolasKion\Esi\DTO\Schematic;
 use NicolasKion\Esi\DTO\Shareholder;
 use NicolasKion\Esi\DTO\Ship;
+use NicolasKion\Esi\DTO\SkillQueueEntry;
 use NicolasKion\Esi\DTO\Sovereignty;
 use NicolasKion\Esi\DTO\Standing;
 use NicolasKion\Esi\DTO\Star;
@@ -119,7 +123,9 @@ use NicolasKion\Esi\Requests\GetAssetNamesRequest;
 use NicolasKion\Esi\Requests\GetAssetsRequest;
 use NicolasKion\Esi\Requests\GetAsteroidBeltRequest;
 use NicolasKion\Esi\Requests\GetBloodlinesRequest;
+use NicolasKion\Esi\Requests\GetCharacterAttributesRequest;
 use NicolasKion\Esi\Requests\GetCharacterBlueprintsRequest;
+use NicolasKion\Esi\Requests\GetCharacterClonesRequest;
 use NicolasKion\Esi\Requests\GetCharacterContactLabelsRequest;
 use NicolasKion\Esi\Requests\GetCharacterContactNotificationsRequest;
 use NicolasKion\Esi\Requests\GetCharacterContactsRequest;
@@ -128,11 +134,14 @@ use NicolasKion\Esi\Requests\GetCharacterContractsRequest;
 use NicolasKion\Esi\Requests\GetCharacterCorporationHistoryRequest;
 use NicolasKion\Esi\Requests\GetCharacterFactionWarfareStatsRequest;
 use NicolasKion\Esi\Requests\GetCharacterFatigueRequest;
+use NicolasKion\Esi\Requests\GetCharacterImplantsRequest;
 use NicolasKion\Esi\Requests\GetCharacterMedalsRequest;
 use NicolasKion\Esi\Requests\GetCharacterNotificationsRequest;
 use NicolasKion\Esi\Requests\GetCharacterPortraitRequest;
 use NicolasKion\Esi\Requests\GetCharacterRequest;
 use NicolasKion\Esi\Requests\GetCharacterRolesRequest;
+use NicolasKion\Esi\Requests\GetCharacterSkillQueueRequest;
+use NicolasKion\Esi\Requests\GetCharacterSkillsRequest;
 use NicolasKion\Esi\Requests\GetCharacterStandingsRequest;
 use NicolasKion\Esi\Requests\GetCharacterTitlesRequest;
 use NicolasKion\Esi\Requests\GetConstellationRequest;
@@ -2041,6 +2050,71 @@ class Esi
     {
         $connector = new Connector;
         $request = new GetRouteRequest($origin_system_id, $destination_system_id, $preference, $avoid_systems, $security_penalty);
+
+        return $connector->send($request);
+    }
+
+    /**
+     * Get character skills
+     *
+     * @return EsiResult<CharacterSkills>
+     */
+    public function getCharacterSkills(Character $character): EsiResult
+    {
+        $connector = $this->getAuthenticatedConnector($character, EsiScope::ReadSkills);
+        $request = new GetCharacterSkillsRequest($character->getId());
+
+        return $connector->send($request);
+    }
+
+    /**
+     * Get character skill queue
+     *
+     * @return EsiResult<array<int, SkillQueueEntry>>
+     */
+    public function getCharacterSkillQueue(Character $character): EsiResult
+    {
+        $connector = $this->getAuthenticatedConnector($character, EsiScope::ReadSkillQueue);
+        $request = new GetCharacterSkillQueueRequest($character->getId());
+
+        return $connector->send($request);
+    }
+
+    /**
+     * Get character attributes
+     *
+     * @return EsiResult<CharacterAttributes>
+     */
+    public function getCharacterAttributes(Character $character): EsiResult
+    {
+        $connector = $this->getAuthenticatedConnector($character, EsiScope::ReadSkills);
+        $request = new GetCharacterAttributesRequest($character->getId());
+
+        return $connector->send($request);
+    }
+
+    /**
+     * Get character clones
+     *
+     * @return EsiResult<CharacterClones>
+     */
+    public function getCharacterClones(Character $character): EsiResult
+    {
+        $connector = $this->getAuthenticatedConnector($character, EsiScope::ReadClones);
+        $request = new GetCharacterClonesRequest($character->getId());
+
+        return $connector->send($request);
+    }
+
+    /**
+     * Get character implants
+     *
+     * @return EsiResult<array<int, int>>
+     */
+    public function getCharacterImplants(Character $character): EsiResult
+    {
+        $connector = $this->getAuthenticatedConnector($character, EsiScope::ReadImplants);
+        $request = new GetCharacterImplantsRequest($character->getId());
 
         return $connector->send($request);
     }

--- a/src/Requests/GetCharacterAttributesRequest.php
+++ b/src/Requests/GetCharacterAttributesRequest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\Requests;
+
+use Illuminate\Http\Client\Response;
+use NicolasKion\Esi\DTO\CharacterAttributes;
+use NicolasKion\Esi\Request;
+
+/**
+ * @extends Request<CharacterAttributes>
+ */
+class GetCharacterAttributesRequest extends Request
+{
+    /**
+     * Create a new class instance.
+     */
+    public function __construct(
+        public int $character_id
+    ) {
+        //
+    }
+
+    public function resolveEndpoint(): string
+    {
+        return sprintf('/characters/%d/attributes/', $this->character_id);
+    }
+
+    public function createDto(Response $response, mixed $data): CharacterAttributes
+    {
+        return CharacterAttributes::hydrate($data);
+    }
+}

--- a/src/Requests/GetCharacterClonesRequest.php
+++ b/src/Requests/GetCharacterClonesRequest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\Requests;
+
+use Illuminate\Http\Client\Response;
+use NicolasKion\Esi\DTO\CharacterClones;
+use NicolasKion\Esi\Request;
+
+/**
+ * @extends Request<CharacterClones>
+ */
+class GetCharacterClonesRequest extends Request
+{
+    /**
+     * Create a new class instance.
+     */
+    public function __construct(
+        public int $character_id
+    ) {
+        //
+    }
+
+    public function resolveEndpoint(): string
+    {
+        return sprintf('/characters/%d/clones/', $this->character_id);
+    }
+
+    public function createDto(Response $response, mixed $data): CharacterClones
+    {
+        return CharacterClones::hydrate($data);
+    }
+}

--- a/src/Requests/GetCharacterImplantsRequest.php
+++ b/src/Requests/GetCharacterImplantsRequest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\Requests;
+
+use Illuminate\Http\Client\Response;
+use NicolasKion\Esi\Request;
+use NicolasKion\Esi\Support\Data;
+
+/**
+ * @extends Request<array<int, int>>
+ */
+class GetCharacterImplantsRequest extends Request
+{
+    /**
+     * Create a new class instance.
+     */
+    public function __construct(
+        public int $character_id
+    ) {
+        //
+    }
+
+    public function resolveEndpoint(): string
+    {
+        return sprintf('/characters/%d/implants/', $this->character_id);
+    }
+
+    /**
+     * @return array<int, int>
+     */
+    public function createDto(Response $response, mixed $data): array
+    {
+        return Data::integerList($data);
+    }
+}

--- a/src/Requests/GetCharacterSkillQueueRequest.php
+++ b/src/Requests/GetCharacterSkillQueueRequest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\Requests;
+
+use Illuminate\Http\Client\Response;
+use NicolasKion\Esi\DTO\SkillQueueEntry;
+use NicolasKion\Esi\Request;
+
+/**
+ * @extends Request<array<int, SkillQueueEntry>>
+ */
+class GetCharacterSkillQueueRequest extends Request
+{
+    /**
+     * Create a new class instance.
+     */
+    public function __construct(
+        public int $character_id
+    ) {
+        //
+    }
+
+    public function resolveEndpoint(): string
+    {
+        return sprintf('/characters/%d/skillqueue/', $this->character_id);
+    }
+
+    /**
+     * @return array<int, SkillQueueEntry>
+     */
+    public function createDto(Response $response, mixed $data): array
+    {
+        return SkillQueueEntry::hydrateList($data);
+    }
+}

--- a/src/Requests/GetCharacterSkillsRequest.php
+++ b/src/Requests/GetCharacterSkillsRequest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\Requests;
+
+use Illuminate\Http\Client\Response;
+use NicolasKion\Esi\DTO\CharacterSkills;
+use NicolasKion\Esi\Request;
+
+/**
+ * @extends Request<CharacterSkills>
+ */
+class GetCharacterSkillsRequest extends Request
+{
+    /**
+     * Create a new class instance.
+     */
+    public function __construct(
+        public int $character_id
+    ) {
+        //
+    }
+
+    public function resolveEndpoint(): string
+    {
+        return sprintf('/characters/%d/skills/', $this->character_id);
+    }
+
+    public function createDto(Response $response, mixed $data): CharacterSkills
+    {
+        return CharacterSkills::hydrate($data);
+    }
+}

--- a/tests/Fixtures/characters/attributes.json
+++ b/tests/Fixtures/characters/attributes.json
@@ -1,0 +1,10 @@
+{
+    "accrued_remap_cooldown_date": "2026-06-09T12:00:00Z",
+    "bonus_remaps": 90000001,
+    "charisma": 90000001,
+    "intelligence": 90000001,
+    "last_remap_date": "2026-06-09T12:00:00Z",
+    "memory": 90000001,
+    "perception": 90000001,
+    "willpower": 90000001
+}

--- a/tests/Fixtures/characters/clones.json
+++ b/tests/Fixtures/characters/clones.json
@@ -1,0 +1,19 @@
+{
+    "home_location": {
+        "location_id": 90000001,
+        "location_type": "station"
+    },
+    "jump_clones": [
+        {
+            "implants": [
+                90000001
+            ],
+            "jump_clone_id": 90000001,
+            "location_id": 90000001,
+            "location_type": "station",
+            "name": "string"
+        }
+    ],
+    "last_clone_jump_date": "2026-06-09T12:00:00Z",
+    "last_station_change_date": "2026-06-09T12:00:00Z"
+}

--- a/tests/Fixtures/characters/skills.json
+++ b/tests/Fixtures/characters/skills.json
@@ -1,0 +1,12 @@
+{
+    "skills": [
+        {
+            "active_skill_level": 90000001,
+            "skill_id": 90000001,
+            "skillpoints_in_skill": 90000001,
+            "trained_skill_level": 90000001
+        }
+    ],
+    "total_sp": 90000001,
+    "unallocated_sp": 90000001
+}

--- a/tests/SkillsClonesTest.php
+++ b/tests/SkillsClonesTest.php
@@ -1,0 +1,209 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Http;
+use NicolasKion\Esi\DTO\CharacterAttributes;
+use NicolasKion\Esi\DTO\CharacterClones;
+use NicolasKion\Esi\DTO\CharacterSkills;
+use NicolasKion\Esi\DTO\CloneHomeLocation;
+use NicolasKion\Esi\DTO\JumpClone;
+use NicolasKion\Esi\DTO\Skill;
+use NicolasKion\Esi\DTO\SkillQueueEntry;
+use NicolasKion\Esi\Esi;
+
+it('fetches and maps character skills', function (): void {
+    Http::fake([
+        'esi.evetech.net/characters/123/skills/' => Http::response(esiFixture('characters/skills.json')),
+    ]);
+
+    $result = (new Esi)->getCharacterSkills(fakeCharacter());
+
+    expect($result->wasSuccessful())->toBeTrue()
+        ->and($result->data)->toBeInstanceOf(CharacterSkills::class)
+        ->and($result->data->skills)->toHaveCount(1)
+        ->and($result->data->skills[0])->toBeInstanceOf(Skill::class)
+        ->and($result->data->skills[0]->skill_id)->toBe(90000001)
+        ->and($result->data->skills[0]->active_skill_level)->toBe(90000001)
+        ->and($result->data->skills[0]->skillpoints_in_skill)->toBe(90000001)
+        ->and($result->data->skills[0]->trained_skill_level)->toBe(90000001)
+        ->and($result->data->total_sp)->toBe(90000001)
+        ->and($result->data->unallocated_sp)->toBe(90000001);
+});
+
+it('fetches and maps character skills with unallocated_sp absent', function (): void {
+    Http::fake([
+        'esi.evetech.net/characters/123/skills/' => Http::response([
+            'skills' => [],
+            'total_sp' => 1,
+        ]),
+    ]);
+
+    $result = (new Esi)->getCharacterSkills(fakeCharacter());
+
+    expect($result->wasSuccessful())->toBeTrue()
+        ->and($result->data->skills)->toBe([])
+        ->and($result->data->total_sp)->toBe(1)
+        ->and($result->data->unallocated_sp)->toBeNull();
+});
+
+it('fetches and maps a character skill queue', function (): void {
+    Http::fake([
+        'esi.evetech.net/characters/123/skillqueue/' => Http::response([
+            [
+                'finish_date' => '2026-06-09T12:00:00Z',
+                'finished_level' => 5,
+                'level_end_sp' => 1000,
+                'level_start_sp' => 500,
+                'queue_position' => 0,
+                'skill_id' => 3300,
+                'start_date' => '2026-05-09T12:00:00Z',
+                'training_start_sp' => 600,
+            ],
+            [
+                // A sparse entry: only the required fields are present.
+                'finished_level' => 3,
+                'queue_position' => 1,
+                'skill_id' => 3301,
+            ],
+        ]),
+    ]);
+
+    $result = (new Esi)->getCharacterSkillQueue(fakeCharacter());
+
+    expect($result->wasSuccessful())->toBeTrue()
+        ->and($result->data)->toHaveCount(2)
+        ->and($result->data[0])->toBeInstanceOf(SkillQueueEntry::class)
+        ->and($result->data[0]->skill_id)->toBe(3300)
+        ->and($result->data[0]->finished_level)->toBe(5)
+        ->and($result->data[0]->queue_position)->toBe(0)
+        ->and($result->data[0]->finish_date)->toBe('2026-06-09T12:00:00Z')
+        ->and($result->data[0]->level_end_sp)->toBe(1000)
+        ->and($result->data[0]->level_start_sp)->toBe(500)
+        ->and($result->data[0]->start_date)->toBe('2026-05-09T12:00:00Z')
+        ->and($result->data[0]->training_start_sp)->toBe(600)
+        ->and($result->data[1]->skill_id)->toBe(3301)
+        ->and($result->data[1]->finished_level)->toBe(3)
+        ->and($result->data[1]->queue_position)->toBe(1)
+        ->and($result->data[1]->finish_date)->toBeNull()
+        ->and($result->data[1]->level_end_sp)->toBeNull()
+        ->and($result->data[1]->level_start_sp)->toBeNull()
+        ->and($result->data[1]->start_date)->toBeNull()
+        ->and($result->data[1]->training_start_sp)->toBeNull();
+});
+
+it('fetches and maps character attributes', function (): void {
+    Http::fake([
+        'esi.evetech.net/characters/123/attributes/' => Http::response(esiFixture('characters/attributes.json')),
+    ]);
+
+    $result = (new Esi)->getCharacterAttributes(fakeCharacter());
+
+    expect($result->wasSuccessful())->toBeTrue()
+        ->and($result->data)->toBeInstanceOf(CharacterAttributes::class)
+        ->and($result->data->charisma)->toBe(90000001)
+        ->and($result->data->intelligence)->toBe(90000001)
+        ->and($result->data->memory)->toBe(90000001)
+        ->and($result->data->perception)->toBe(90000001)
+        ->and($result->data->willpower)->toBe(90000001)
+        ->and($result->data->accrued_remap_cooldown_date)->toBe('2026-06-09T12:00:00Z')
+        ->and($result->data->bonus_remaps)->toBe(90000001)
+        ->and($result->data->last_remap_date)->toBe('2026-06-09T12:00:00Z');
+});
+
+it('fetches and maps character attributes with optional fields absent', function (): void {
+    Http::fake([
+        'esi.evetech.net/characters/123/attributes/' => Http::response([
+            'charisma' => 1,
+            'intelligence' => 2,
+            'memory' => 3,
+            'perception' => 4,
+            'willpower' => 5,
+        ]),
+    ]);
+
+    $result = (new Esi)->getCharacterAttributes(fakeCharacter());
+
+    expect($result->wasSuccessful())->toBeTrue()
+        ->and($result->data->accrued_remap_cooldown_date)->toBeNull()
+        ->and($result->data->bonus_remaps)->toBeNull()
+        ->and($result->data->last_remap_date)->toBeNull();
+});
+
+it('fetches and maps character clones', function (): void {
+    Http::fake([
+        'esi.evetech.net/characters/123/clones/' => Http::response(esiFixture('characters/clones.json')),
+    ]);
+
+    $result = (new Esi)->getCharacterClones(fakeCharacter());
+
+    expect($result->wasSuccessful())->toBeTrue()
+        ->and($result->data)->toBeInstanceOf(CharacterClones::class)
+        ->and($result->data->home_location)->toBeInstanceOf(CloneHomeLocation::class)
+        ->and($result->data->home_location->location_id)->toBe(90000001)
+        ->and($result->data->home_location->location_type)->toBe('station')
+        ->and($result->data->jump_clones)->toHaveCount(1)
+        ->and($result->data->jump_clones[0])->toBeInstanceOf(JumpClone::class)
+        ->and($result->data->jump_clones[0]->jump_clone_id)->toBe(90000001)
+        ->and($result->data->jump_clones[0]->location_id)->toBe(90000001)
+        ->and($result->data->jump_clones[0]->location_type)->toBe('station')
+        ->and($result->data->jump_clones[0]->implants)->toBe([90000001])
+        ->and($result->data->jump_clones[0]->name)->toBe('string')
+        ->and($result->data->last_clone_jump_date)->toBe('2026-06-09T12:00:00Z')
+        ->and($result->data->last_station_change_date)->toBe('2026-06-09T12:00:00Z');
+});
+
+it('fetches and maps character clones with optional fields absent', function (): void {
+    Http::fake([
+        'esi.evetech.net/characters/123/clones/' => Http::response([
+            'jump_clones' => [
+                [
+                    'implants' => [],
+                    'jump_clone_id' => 1,
+                    'location_id' => 2,
+                    'location_type' => 'structure',
+                ],
+            ],
+        ]),
+    ]);
+
+    $result = (new Esi)->getCharacterClones(fakeCharacter());
+
+    expect($result->wasSuccessful())->toBeTrue()
+        ->and($result->data->home_location)->toBeInstanceOf(CloneHomeLocation::class)
+        ->and($result->data->home_location->location_id)->toBeNull()
+        ->and($result->data->home_location->location_type)->toBeNull()
+        ->and($result->data->jump_clones[0]->implants)->toBe([])
+        ->and($result->data->jump_clones[0]->name)->toBeNull()
+        ->and($result->data->last_clone_jump_date)->toBeNull()
+        ->and($result->data->last_station_change_date)->toBeNull();
+});
+
+it('fetches and maps character implants', function (): void {
+    Http::fake([
+        'esi.evetech.net/characters/123/implants/' => Http::response([90000001, 90000002]),
+    ]);
+
+    $result = (new Esi)->getCharacterImplants(fakeCharacter());
+
+    expect($result->wasSuccessful())->toBeTrue()
+        ->and($result->data)->toBe([90000001, 90000002]);
+});
+
+it('returns an error result when a skills/clones endpoint fails with a server error', function (): void {
+    Http::fake([
+        'esi.evetech.net/characters/123/skills/' => Http::response(['error' => 'Internal server error'], 500),
+        'esi.evetech.net/characters/123/skillqueue/' => Http::response(['error' => 'Internal server error'], 500),
+        'esi.evetech.net/characters/123/attributes/' => Http::response(['error' => 'Internal server error'], 500),
+        'esi.evetech.net/characters/123/clones/' => Http::response(['error' => 'Internal server error'], 500),
+        'esi.evetech.net/characters/123/implants/' => Http::response(['error' => 'Internal server error'], 500),
+    ]);
+
+    $esi = new Esi;
+
+    expect($esi->getCharacterSkills(fakeCharacter())->failed())->toBeTrue()
+        ->and($esi->getCharacterSkillQueue(fakeCharacter())->failed())->toBeTrue()
+        ->and($esi->getCharacterAttributes(fakeCharacter())->failed())->toBeTrue()
+        ->and($esi->getCharacterClones(fakeCharacter())->failed())->toBeTrue()
+        ->and($esi->getCharacterImplants(fakeCharacter())->failed())->toBeTrue();
+});


### PR DESCRIPTION
Skills (skills/skillqueue/attributes) and Clones (clones/implants) domains — 5 authenticated character endpoints. 7 DTOs, 4 new scopes. PHPStan level 9 clean, 100% coverage (208 tests).