### PR TITLE
feat: add fleet endpoints

### DIFF
--- a/src/DTO/Fleet.php
+++ b/src/DTO/Fleet.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\DTO;
+
+use NicolasKion\Esi\Support\Data;
+
+readonly class Fleet extends Dto
+{
+    public function __construct(
+        public bool $is_free_move,
+        public bool $is_registered,
+        public bool $is_voice_enabled,
+        public ?string $motd,
+    ) {}
+
+    public static function fromData(Data $data): self
+    {
+        return new self(
+            is_free_move: $data->boolean('is_free_move', false),
+            is_registered: $data->boolean('is_registered', false),
+            is_voice_enabled: $data->boolean('is_voice_enabled', false),
+            motd: $data->string('motd'),
+        );
+    }
+}

--- a/src/DTO/FleetInfo.php
+++ b/src/DTO/FleetInfo.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\DTO;
+
+use NicolasKion\Esi\Support\Data;
+
+readonly class FleetInfo extends Dto
+{
+    public function __construct(
+        public int $fleet_id,
+        public int $fleet_boss_id,
+        public string $role,
+        public int $squad_id,
+        public int $wing_id,
+    ) {}
+
+    public static function fromData(Data $data): self
+    {
+        return new self(
+            fleet_id: $data->integer('fleet_id', 0),
+            fleet_boss_id: $data->integer('fleet_boss_id', 0),
+            role: $data->string('role', ''),
+            squad_id: $data->integer('squad_id', 0),
+            wing_id: $data->integer('wing_id', 0),
+        );
+    }
+}

--- a/src/DTO/FleetMember.php
+++ b/src/DTO/FleetMember.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\DTO;
+
+use NicolasKion\Esi\Support\Data;
+
+readonly class FleetMember extends Dto
+{
+    public function __construct(
+        public int $character_id,
+        public int $ship_type_id,
+        public int $solar_system_id,
+        public int $squad_id,
+        public int $wing_id,
+        public string $role,
+        public string $role_name,
+        public string $join_time,
+        public ?int $station_id,
+        public bool $takes_fleet_warp,
+    ) {}
+
+    public static function fromData(Data $data): self
+    {
+        return new self(
+            character_id: $data->integer('character_id', 0),
+            ship_type_id: $data->integer('ship_type_id', 0),
+            solar_system_id: $data->integer('solar_system_id', 0),
+            squad_id: $data->integer('squad_id', 0),
+            wing_id: $data->integer('wing_id', 0),
+            role: $data->string('role', ''),
+            role_name: $data->string('role_name', ''),
+            join_time: $data->string('join_time', ''),
+            station_id: $data->integer('station_id'),
+            takes_fleet_warp: $data->boolean('takes_fleet_warp', false),
+        );
+    }
+}

--- a/src/DTO/FleetSquad.php
+++ b/src/DTO/FleetSquad.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\DTO;
+
+use NicolasKion\Esi\Support\Data;
+
+readonly class FleetSquad extends Dto
+{
+    public function __construct(
+        public int $id,
+        public string $name,
+    ) {}
+
+    public static function fromData(Data $data): self
+    {
+        return new self(
+            id: $data->integer('id', 0),
+            name: $data->string('name', ''),
+        );
+    }
+}

--- a/src/DTO/FleetWing.php
+++ b/src/DTO/FleetWing.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\DTO;
+
+use NicolasKion\Esi\Support\Data;
+
+readonly class FleetWing extends Dto
+{
+    /**
+     * @param  array<int, FleetSquad>  $squads
+     */
+    public function __construct(
+        public int $id,
+        public string $name,
+        public array $squads,
+    ) {}
+
+    public static function fromData(Data $data): self
+    {
+        return new self(
+            id: $data->integer('id', 0),
+            name: $data->string('name', ''),
+            squads: $data->list('squads', FleetSquad::fromData(...)),
+        );
+    }
+}

--- a/src/Enums/EsiScope.php
+++ b/src/Enums/EsiScope.php
@@ -51,6 +51,8 @@ enum EsiScope: string
     case ReadSkillQueue = 'esi-skills.read_skillqueue.v1';
     case ReadClones = 'esi-clones.read_clones.v1';
     case ReadImplants = 'esi-clones.read_implants.v1';
+    case ReadFleet = 'esi-fleets.read_fleet.v1';
+    case WriteFleet = 'esi-fleets.write_fleet.v1';
 
     /**
      * @return array<int, string>

--- a/src/Esi.php
+++ b/src/Esi.php
@@ -54,6 +54,10 @@ use NicolasKion\Esi\DTO\FactionWarfareFactionStats;
 use NicolasKion\Esi\DTO\FactionWarfareLeaderboard;
 use NicolasKion\Esi\DTO\FactionWarfareSystem;
 use NicolasKion\Esi\DTO\FactionWarfareWar;
+use NicolasKion\Esi\DTO\Fleet;
+use NicolasKion\Esi\DTO\FleetInfo;
+use NicolasKion\Esi\DTO\FleetMember;
+use NicolasKion\Esi\DTO\FleetWing;
 use NicolasKion\Esi\DTO\Graphic;
 use NicolasKion\Esi\DTO\Incursion;
 use NicolasKion\Esi\DTO\InsurancePrice;
@@ -108,7 +112,11 @@ use NicolasKion\Esi\Enums\MarketOrderType;
 use NicolasKion\Esi\Enums\RoutePreference;
 use NicolasKion\Esi\Interfaces\Character;
 use NicolasKion\Esi\Requests\AddCharacterContactsRequest;
+use NicolasKion\Esi\Requests\CreateFleetSquadRequest;
+use NicolasKion\Esi\Requests\CreateFleetWingRequest;
 use NicolasKion\Esi\Requests\DeleteCharacterContactsRequest;
+use NicolasKion\Esi\Requests\DeleteFleetSquadRequest;
+use NicolasKion\Esi\Requests\DeleteFleetWingRequest;
 use NicolasKion\Esi\Requests\EditCharacterContactsRequest;
 use NicolasKion\Esi\Requests\GetAffiliationsRequest;
 use NicolasKion\Esi\Requests\GetAgentsResearchRequest;
@@ -134,6 +142,7 @@ use NicolasKion\Esi\Requests\GetCharacterContractsRequest;
 use NicolasKion\Esi\Requests\GetCharacterCorporationHistoryRequest;
 use NicolasKion\Esi\Requests\GetCharacterFactionWarfareStatsRequest;
 use NicolasKion\Esi\Requests\GetCharacterFatigueRequest;
+use NicolasKion\Esi\Requests\GetCharacterFleetRequest;
 use NicolasKion\Esi\Requests\GetCharacterImplantsRequest;
 use NicolasKion\Esi\Requests\GetCharacterMedalsRequest;
 use NicolasKion\Esi\Requests\GetCharacterNotificationsRequest;
@@ -189,6 +198,9 @@ use NicolasKion\Esi\Requests\GetFactionWarfareLeaderboardsRequest;
 use NicolasKion\Esi\Requests\GetFactionWarfareStatsRequest;
 use NicolasKion\Esi\Requests\GetFactionWarfareSystemsRequest;
 use NicolasKion\Esi\Requests\GetFactionWarfareWarsRequest;
+use NicolasKion\Esi\Requests\GetFleetMembersRequest;
+use NicolasKion\Esi\Requests\GetFleetRequest;
+use NicolasKion\Esi\Requests\GetFleetWingsRequest;
 use NicolasKion\Esi\Requests\GetGraphicRequest;
 use NicolasKion\Esi\Requests\GetIdsRequest;
 use NicolasKion\Esi\Requests\GetIncursionsRequest;
@@ -240,9 +252,15 @@ use NicolasKion\Esi\Requests\GetWalletBalanceRequest;
 use NicolasKion\Esi\Requests\GetWalletJournalRequest;
 use NicolasKion\Esi\Requests\GetWalletTransactionsRequest;
 use NicolasKion\Esi\Requests\GetWarRequest;
+use NicolasKion\Esi\Requests\InviteFleetMemberRequest;
+use NicolasKion\Esi\Requests\KickFleetMemberRequest;
+use NicolasKion\Esi\Requests\MoveFleetMemberRequest;
 use NicolasKion\Esi\Requests\OpenContractRequest;
+use NicolasKion\Esi\Requests\RenameFleetSquadRequest;
+use NicolasKion\Esi\Requests\RenameFleetWingRequest;
 use NicolasKion\Esi\Requests\SendMailRequest;
 use NicolasKion\Esi\Requests\UpdateEveMailRequest;
+use NicolasKion\Esi\Requests\UpdateFleetRequest;
 
 class Esi
 {
@@ -2115,6 +2133,188 @@ class Esi
     {
         $connector = $this->getAuthenticatedConnector($character, EsiScope::ReadImplants);
         $request = new GetCharacterImplantsRequest($character->getId());
+
+        return $connector->send($request);
+    }
+
+    /**
+     * Retrieves the fleet information of a character.
+     *
+     * @return EsiResult<FleetInfo>
+     */
+    public function getCharacterFleet(Character $character): EsiResult
+    {
+        $connector = $this->getAuthenticatedConnector($character, EsiScope::ReadFleet);
+        $request = new GetCharacterFleetRequest($character->getId());
+
+        return $connector->send($request);
+    }
+
+    /**
+     * Retrieves information about a fleet.
+     *
+     * @return EsiResult<Fleet>
+     */
+    public function getFleet(Character $character, int $fleet_id): EsiResult
+    {
+        $connector = $this->getAuthenticatedConnector($character, EsiScope::ReadFleet);
+        $request = new GetFleetRequest($fleet_id);
+
+        return $connector->send($request);
+    }
+
+    /**
+     * Retrieves the members of a fleet.
+     *
+     * @return EsiResult<array<int, FleetMember>>
+     */
+    public function getFleetMembers(Character $character, int $fleet_id): EsiResult
+    {
+        $connector = $this->getAuthenticatedConnector($character, EsiScope::ReadFleet);
+        $request = new GetFleetMembersRequest($fleet_id);
+
+        return $connector->send($request);
+    }
+
+    /**
+     * Retrieves the wings of a fleet.
+     *
+     * @return EsiResult<array<int, FleetWing>>
+     */
+    public function getFleetWings(Character $character, int $fleet_id): EsiResult
+    {
+        $connector = $this->getAuthenticatedConnector($character, EsiScope::ReadFleet);
+        $request = new GetFleetWingsRequest($fleet_id);
+
+        return $connector->send($request);
+    }
+
+    /**
+     * Updates settings of a fleet.
+     *
+     * @return EsiResult<null>
+     */
+    public function updateFleet(Character $character, int $fleet_id, ?bool $is_free_move = null, ?string $motd = null): EsiResult
+    {
+        $connector = $this->getAuthenticatedConnector($character, EsiScope::WriteFleet);
+        $request = new UpdateFleetRequest($fleet_id, $is_free_move, $motd);
+
+        return $connector->send($request);
+    }
+
+    /**
+     * Invites a character into a fleet.
+     *
+     * @return EsiResult<null>
+     */
+    public function inviteFleetMember(Character $character, int $fleet_id, int $character_id, string $role, ?int $squad_id = null, ?int $wing_id = null): EsiResult
+    {
+        $connector = $this->getAuthenticatedConnector($character, EsiScope::WriteFleet);
+        $request = new InviteFleetMemberRequest($fleet_id, $character_id, $role, $squad_id, $wing_id);
+
+        return $connector->send($request);
+    }
+
+    /**
+     * Kicks a member out of a fleet.
+     *
+     * @return EsiResult<null>
+     */
+    public function kickFleetMember(Character $character, int $fleet_id, int $member_id): EsiResult
+    {
+        $connector = $this->getAuthenticatedConnector($character, EsiScope::WriteFleet);
+        $request = new KickFleetMemberRequest($fleet_id, $member_id);
+
+        return $connector->send($request);
+    }
+
+    /**
+     * Moves a fleet member to a new role or squad/wing.
+     *
+     * @return EsiResult<null>
+     */
+    public function moveFleetMember(Character $character, int $fleet_id, int $member_id, string $role, ?int $squad_id = null, ?int $wing_id = null): EsiResult
+    {
+        $connector = $this->getAuthenticatedConnector($character, EsiScope::WriteFleet);
+        $request = new MoveFleetMemberRequest($fleet_id, $member_id, $role, $squad_id, $wing_id);
+
+        return $connector->send($request);
+    }
+
+    /**
+     * Creates a new wing in a fleet.
+     *
+     * @return EsiResult<int> The ID of the new wing.
+     */
+    public function createFleetWing(Character $character, int $fleet_id): EsiResult
+    {
+        $connector = $this->getAuthenticatedConnector($character, EsiScope::WriteFleet);
+        $request = new CreateFleetWingRequest($fleet_id);
+
+        return $connector->send($request);
+    }
+
+    /**
+     * Deletes a wing from a fleet.
+     *
+     * @return EsiResult<null>
+     */
+    public function deleteFleetWing(Character $character, int $fleet_id, int $wing_id): EsiResult
+    {
+        $connector = $this->getAuthenticatedConnector($character, EsiScope::WriteFleet);
+        $request = new DeleteFleetWingRequest($fleet_id, $wing_id);
+
+        return $connector->send($request);
+    }
+
+    /**
+     * Renames a fleet wing.
+     *
+     * @return EsiResult<null>
+     */
+    public function renameFleetWing(Character $character, int $fleet_id, int $wing_id, string $name): EsiResult
+    {
+        $connector = $this->getAuthenticatedConnector($character, EsiScope::WriteFleet);
+        $request = new RenameFleetWingRequest($fleet_id, $wing_id, $name);
+
+        return $connector->send($request);
+    }
+
+    /**
+     * Creates a new squad in a fleet wing.
+     *
+     * @return EsiResult<int> The ID of the new squad.
+     */
+    public function createFleetSquad(Character $character, int $fleet_id, int $wing_id): EsiResult
+    {
+        $connector = $this->getAuthenticatedConnector($character, EsiScope::WriteFleet);
+        $request = new CreateFleetSquadRequest($fleet_id, $wing_id);
+
+        return $connector->send($request);
+    }
+
+    /**
+     * Deletes a squad from a fleet.
+     *
+     * @return EsiResult<null>
+     */
+    public function deleteFleetSquad(Character $character, int $fleet_id, int $squad_id): EsiResult
+    {
+        $connector = $this->getAuthenticatedConnector($character, EsiScope::WriteFleet);
+        $request = new DeleteFleetSquadRequest($fleet_id, $squad_id);
+
+        return $connector->send($request);
+    }
+
+    /**
+     * Renames a fleet squad.
+     *
+     * @return EsiResult<null>
+     */
+    public function renameFleetSquad(Character $character, int $fleet_id, int $squad_id, string $name): EsiResult
+    {
+        $connector = $this->getAuthenticatedConnector($character, EsiScope::WriteFleet);
+        $request = new RenameFleetSquadRequest($fleet_id, $squad_id, $name);
 
         return $connector->send($request);
     }

--- a/src/Requests/CreateFleetSquadRequest.php
+++ b/src/Requests/CreateFleetSquadRequest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\Requests;
+
+use Illuminate\Http\Client\Response;
+use NicolasKion\Esi\Enums\RequestMethod;
+use NicolasKion\Esi\Request;
+use NicolasKion\Esi\Support\Data;
+
+/**
+ * @extends Request<int>
+ */
+class CreateFleetSquadRequest extends Request
+{
+    public function __construct(
+        public int $fleet_id,
+        public int $wing_id,
+    ) {}
+
+    public function resolveEndpoint(): string
+    {
+        return sprintf('/fleets/%d/wings/%d/squads/', $this->fleet_id, $this->wing_id);
+    }
+
+    public function getMethod(): RequestMethod
+    {
+        return RequestMethod::POST;
+    }
+
+    public function createDto(Response $response, mixed $data): int
+    {
+        return Data::of($data)->integer('squad_id', 0);
+    }
+
+    public function shouldRetry(Response $response): bool
+    {
+        return false;
+    }
+}

--- a/src/Requests/CreateFleetWingRequest.php
+++ b/src/Requests/CreateFleetWingRequest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\Requests;
+
+use Illuminate\Http\Client\Response;
+use NicolasKion\Esi\Enums\RequestMethod;
+use NicolasKion\Esi\Request;
+use NicolasKion\Esi\Support\Data;
+
+/**
+ * @extends Request<int>
+ */
+class CreateFleetWingRequest extends Request
+{
+    public function __construct(
+        public int $fleet_id,
+    ) {}
+
+    public function resolveEndpoint(): string
+    {
+        return sprintf('/fleets/%d/wings/', $this->fleet_id);
+    }
+
+    public function getMethod(): RequestMethod
+    {
+        return RequestMethod::POST;
+    }
+
+    public function createDto(Response $response, mixed $data): int
+    {
+        return Data::of($data)->integer('wing_id', 0);
+    }
+
+    public function shouldRetry(Response $response): bool
+    {
+        return false;
+    }
+}

--- a/src/Requests/DeleteFleetSquadRequest.php
+++ b/src/Requests/DeleteFleetSquadRequest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\Requests;
+
+use Illuminate\Http\Client\Response;
+use NicolasKion\Esi\Enums\RequestMethod;
+use NicolasKion\Esi\Request;
+
+/**
+ * @extends Request<null>
+ */
+class DeleteFleetSquadRequest extends Request
+{
+    public function __construct(
+        public int $fleet_id,
+        public int $squad_id,
+    ) {}
+
+    public function resolveEndpoint(): string
+    {
+        return sprintf('/fleets/%d/squads/%d/', $this->fleet_id, $this->squad_id);
+    }
+
+    public function getMethod(): RequestMethod
+    {
+        return RequestMethod::DELETE;
+    }
+
+    public function createDto(Response $response, mixed $data): null
+    {
+        return null;
+    }
+
+    public function shouldRetry(Response $response): bool
+    {
+        return false;
+    }
+}

--- a/src/Requests/DeleteFleetWingRequest.php
+++ b/src/Requests/DeleteFleetWingRequest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\Requests;
+
+use Illuminate\Http\Client\Response;
+use NicolasKion\Esi\Enums\RequestMethod;
+use NicolasKion\Esi\Request;
+
+/**
+ * @extends Request<null>
+ */
+class DeleteFleetWingRequest extends Request
+{
+    public function __construct(
+        public int $fleet_id,
+        public int $wing_id,
+    ) {}
+
+    public function resolveEndpoint(): string
+    {
+        return sprintf('/fleets/%d/wings/%d/', $this->fleet_id, $this->wing_id);
+    }
+
+    public function getMethod(): RequestMethod
+    {
+        return RequestMethod::DELETE;
+    }
+
+    public function createDto(Response $response, mixed $data): null
+    {
+        return null;
+    }
+
+    public function shouldRetry(Response $response): bool
+    {
+        return false;
+    }
+}

--- a/src/Requests/GetCharacterFleetRequest.php
+++ b/src/Requests/GetCharacterFleetRequest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\Requests;
+
+use Illuminate\Http\Client\Response;
+use NicolasKion\Esi\DTO\FleetInfo;
+use NicolasKion\Esi\Request;
+
+/**
+ * @extends Request<FleetInfo>
+ */
+class GetCharacterFleetRequest extends Request
+{
+    public function __construct(
+        public int $character_id
+    ) {
+        //
+    }
+
+    public function resolveEndpoint(): string
+    {
+        return sprintf('/characters/%d/fleet/', $this->character_id);
+    }
+
+    public function createDto(Response $response, mixed $data): FleetInfo
+    {
+        return FleetInfo::hydrate($data);
+    }
+}

--- a/src/Requests/GetFleetMembersRequest.php
+++ b/src/Requests/GetFleetMembersRequest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\Requests;
+
+use Illuminate\Http\Client\Response;
+use NicolasKion\Esi\DTO\FleetMember;
+use NicolasKion\Esi\Request;
+
+/**
+ * @extends Request<array<int, FleetMember>>
+ */
+class GetFleetMembersRequest extends Request
+{
+    public function __construct(
+        public int $fleet_id
+    ) {
+        //
+    }
+
+    public function resolveEndpoint(): string
+    {
+        return sprintf('/fleets/%d/members/', $this->fleet_id);
+    }
+
+    /**
+     * @return array<int, FleetMember>
+     */
+    public function createDto(Response $response, mixed $data): array
+    {
+        return FleetMember::hydrateList($data);
+    }
+}

--- a/src/Requests/GetFleetRequest.php
+++ b/src/Requests/GetFleetRequest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\Requests;
+
+use Illuminate\Http\Client\Response;
+use NicolasKion\Esi\DTO\Fleet;
+use NicolasKion\Esi\Request;
+
+/**
+ * @extends Request<Fleet>
+ */
+class GetFleetRequest extends Request
+{
+    public function __construct(
+        public int $fleet_id
+    ) {
+        //
+    }
+
+    public function resolveEndpoint(): string
+    {
+        return sprintf('/fleets/%d/', $this->fleet_id);
+    }
+
+    public function createDto(Response $response, mixed $data): Fleet
+    {
+        return Fleet::hydrate($data);
+    }
+}

--- a/src/Requests/GetFleetWingsRequest.php
+++ b/src/Requests/GetFleetWingsRequest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\Requests;
+
+use Illuminate\Http\Client\Response;
+use NicolasKion\Esi\DTO\FleetWing;
+use NicolasKion\Esi\Request;
+
+/**
+ * @extends Request<array<int, FleetWing>>
+ */
+class GetFleetWingsRequest extends Request
+{
+    public function __construct(
+        public int $fleet_id
+    ) {
+        //
+    }
+
+    public function resolveEndpoint(): string
+    {
+        return sprintf('/fleets/%d/wings/', $this->fleet_id);
+    }
+
+    /**
+     * @return array<int, FleetWing>
+     */
+    public function createDto(Response $response, mixed $data): array
+    {
+        return FleetWing::hydrateList($data);
+    }
+}

--- a/src/Requests/InviteFleetMemberRequest.php
+++ b/src/Requests/InviteFleetMemberRequest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\Requests;
+
+use Illuminate\Http\Client\Response;
+use NicolasKion\Esi\Enums\RequestMethod;
+use NicolasKion\Esi\Interfaces\WithBody;
+use NicolasKion\Esi\Request;
+
+/**
+ * @extends Request<null>
+ */
+class InviteFleetMemberRequest extends Request implements WithBody
+{
+    public function __construct(
+        public int $fleet_id,
+        public int $character_id,
+        public string $role,
+        public ?int $squad_id = null,
+        public ?int $wing_id = null,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getBody(): array
+    {
+        $data = [
+            'character_id' => $this->character_id,
+            'role' => $this->role,
+        ];
+
+        if ($this->squad_id !== null) {
+            $data['squad_id'] = $this->squad_id;
+        }
+
+        if ($this->wing_id !== null) {
+            $data['wing_id'] = $this->wing_id;
+        }
+
+        return $data;
+    }
+
+    public function resolveEndpoint(): string
+    {
+        return sprintf('/fleets/%d/members/', $this->fleet_id);
+    }
+
+    public function getMethod(): RequestMethod
+    {
+        return RequestMethod::POST;
+    }
+
+    public function createDto(Response $response, mixed $data): null
+    {
+        return null;
+    }
+
+    public function shouldRetry(Response $response): bool
+    {
+        return false;
+    }
+}

--- a/src/Requests/KickFleetMemberRequest.php
+++ b/src/Requests/KickFleetMemberRequest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\Requests;
+
+use Illuminate\Http\Client\Response;
+use NicolasKion\Esi\Enums\RequestMethod;
+use NicolasKion\Esi\Request;
+
+/**
+ * @extends Request<null>
+ */
+class KickFleetMemberRequest extends Request
+{
+    public function __construct(
+        public int $fleet_id,
+        public int $member_id,
+    ) {}
+
+    public function resolveEndpoint(): string
+    {
+        return sprintf('/fleets/%d/members/%d/', $this->fleet_id, $this->member_id);
+    }
+
+    public function getMethod(): RequestMethod
+    {
+        return RequestMethod::DELETE;
+    }
+
+    public function createDto(Response $response, mixed $data): null
+    {
+        return null;
+    }
+
+    public function shouldRetry(Response $response): bool
+    {
+        return false;
+    }
+}

--- a/src/Requests/MoveFleetMemberRequest.php
+++ b/src/Requests/MoveFleetMemberRequest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\Requests;
+
+use Illuminate\Http\Client\Response;
+use NicolasKion\Esi\Enums\RequestMethod;
+use NicolasKion\Esi\Interfaces\WithBody;
+use NicolasKion\Esi\Request;
+
+/**
+ * @extends Request<null>
+ */
+class MoveFleetMemberRequest extends Request implements WithBody
+{
+    public function __construct(
+        public int $fleet_id,
+        public int $member_id,
+        public string $role,
+        public ?int $squad_id = null,
+        public ?int $wing_id = null,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getBody(): array
+    {
+        $data = [
+            'role' => $this->role,
+        ];
+
+        if ($this->squad_id !== null) {
+            $data['squad_id'] = $this->squad_id;
+        }
+
+        if ($this->wing_id !== null) {
+            $data['wing_id'] = $this->wing_id;
+        }
+
+        return $data;
+    }
+
+    public function resolveEndpoint(): string
+    {
+        return sprintf('/fleets/%d/members/%d/', $this->fleet_id, $this->member_id);
+    }
+
+    public function getMethod(): RequestMethod
+    {
+        return RequestMethod::PUT;
+    }
+
+    public function createDto(Response $response, mixed $data): null
+    {
+        return null;
+    }
+
+    public function shouldRetry(Response $response): bool
+    {
+        return true;
+    }
+}

--- a/src/Requests/RenameFleetSquadRequest.php
+++ b/src/Requests/RenameFleetSquadRequest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\Requests;
+
+use Illuminate\Http\Client\Response;
+use NicolasKion\Esi\Enums\RequestMethod;
+use NicolasKion\Esi\Interfaces\WithBody;
+use NicolasKion\Esi\Request;
+
+/**
+ * @extends Request<null>
+ */
+class RenameFleetSquadRequest extends Request implements WithBody
+{
+    public function __construct(
+        public int $fleet_id,
+        public int $squad_id,
+        public string $name,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getBody(): array
+    {
+        return [
+            'name' => $this->name,
+        ];
+    }
+
+    public function resolveEndpoint(): string
+    {
+        return sprintf('/fleets/%d/squads/%d/', $this->fleet_id, $this->squad_id);
+    }
+
+    public function getMethod(): RequestMethod
+    {
+        return RequestMethod::PUT;
+    }
+
+    public function createDto(Response $response, mixed $data): null
+    {
+        return null;
+    }
+
+    public function shouldRetry(Response $response): bool
+    {
+        return true;
+    }
+}

--- a/src/Requests/RenameFleetWingRequest.php
+++ b/src/Requests/RenameFleetWingRequest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\Requests;
+
+use Illuminate\Http\Client\Response;
+use NicolasKion\Esi\Enums\RequestMethod;
+use NicolasKion\Esi\Interfaces\WithBody;
+use NicolasKion\Esi\Request;
+
+/**
+ * @extends Request<null>
+ */
+class RenameFleetWingRequest extends Request implements WithBody
+{
+    public function __construct(
+        public int $fleet_id,
+        public int $wing_id,
+        public string $name,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getBody(): array
+    {
+        return [
+            'name' => $this->name,
+        ];
+    }
+
+    public function resolveEndpoint(): string
+    {
+        return sprintf('/fleets/%d/wings/%d/', $this->fleet_id, $this->wing_id);
+    }
+
+    public function getMethod(): RequestMethod
+    {
+        return RequestMethod::PUT;
+    }
+
+    public function createDto(Response $response, mixed $data): null
+    {
+        return null;
+    }
+
+    public function shouldRetry(Response $response): bool
+    {
+        return true;
+    }
+}

--- a/src/Requests/UpdateFleetRequest.php
+++ b/src/Requests/UpdateFleetRequest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\Requests;
+
+use Illuminate\Http\Client\Response;
+use NicolasKion\Esi\Enums\RequestMethod;
+use NicolasKion\Esi\Interfaces\WithBody;
+use NicolasKion\Esi\Request;
+
+/**
+ * @extends Request<null>
+ */
+class UpdateFleetRequest extends Request implements WithBody
+{
+    public function __construct(
+        public int $fleet_id,
+        public ?bool $is_free_move = null,
+        public ?string $motd = null,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getBody(): array
+    {
+        $data = [];
+
+        if ($this->is_free_move !== null) {
+            $data['is_free_move'] = $this->is_free_move;
+        }
+
+        if ($this->motd !== null) {
+            $data['motd'] = $this->motd;
+        }
+
+        return $data;
+    }
+
+    public function resolveEndpoint(): string
+    {
+        return sprintf('/fleets/%d/', $this->fleet_id);
+    }
+
+    public function getMethod(): RequestMethod
+    {
+        return RequestMethod::PUT;
+    }
+
+    public function createDto(Response $response, mixed $data): null
+    {
+        return null;
+    }
+
+    public function shouldRetry(Response $response): bool
+    {
+        return true;
+    }
+}

--- a/tests/FleetTest.php
+++ b/tests/FleetTest.php
@@ -1,0 +1,373 @@
+<?php
+
+declare(strict_types=1);
+
+use GuzzleHttp\Psr7\Response as Psr7Response;
+use Illuminate\Http\Client\Response;
+use Illuminate\Support\Facades\Http;
+use NicolasKion\Esi\DTO\Fleet;
+use NicolasKion\Esi\DTO\FleetInfo;
+use NicolasKion\Esi\DTO\FleetMember;
+use NicolasKion\Esi\DTO\FleetWing;
+use NicolasKion\Esi\Esi;
+use NicolasKion\Esi\Requests\CreateFleetSquadRequest;
+use NicolasKion\Esi\Requests\CreateFleetWingRequest;
+use NicolasKion\Esi\Requests\DeleteFleetSquadRequest;
+use NicolasKion\Esi\Requests\DeleteFleetWingRequest;
+use NicolasKion\Esi\Requests\InviteFleetMemberRequest;
+use NicolasKion\Esi\Requests\KickFleetMemberRequest;
+use NicolasKion\Esi\Requests\MoveFleetMemberRequest;
+use NicolasKion\Esi\Requests\RenameFleetSquadRequest;
+use NicolasKion\Esi\Requests\RenameFleetWingRequest;
+use NicolasKion\Esi\Requests\UpdateFleetRequest;
+
+it('fetches and maps the fleet a character belongs to', function (): void {
+    Http::fake([
+        'esi.evetech.net/characters/123/fleet/' => Http::response([
+            'fleet_boss_id' => 90000001,
+            'fleet_id' => 90000002,
+            'role' => 'fleet_commander',
+            'squad_id' => 90000003,
+            'wing_id' => 90000004,
+        ]),
+    ]);
+
+    $result = (new Esi)->getCharacterFleet(fakeCharacter());
+
+    expect($result->wasSuccessful())->toBeTrue()
+        ->and($result->data)->toBeInstanceOf(FleetInfo::class)
+        ->and($result->data->fleet_boss_id)->toBe(90000001)
+        ->and($result->data->fleet_id)->toBe(90000002)
+        ->and($result->data->role)->toBe('fleet_commander')
+        ->and($result->data->squad_id)->toBe(90000003)
+        ->and($result->data->wing_id)->toBe(90000004);
+});
+
+it('fetches and maps a fleet', function (): void {
+    Http::fake([
+        'esi.evetech.net/fleets/1/' => Http::response([
+            'is_free_move' => true,
+            'is_registered' => true,
+            'is_voice_enabled' => true,
+            'motd' => 'string',
+        ]),
+    ]);
+
+    $result = (new Esi)->getFleet(fakeCharacter(), 1);
+
+    expect($result->wasSuccessful())->toBeTrue()
+        ->and($result->data)->toBeInstanceOf(Fleet::class)
+        ->and($result->data->is_free_move)->toBeTrue()
+        ->and($result->data->is_registered)->toBeTrue()
+        ->and($result->data->is_voice_enabled)->toBeTrue()
+        ->and($result->data->motd)->toBe('string');
+});
+
+it('fetches and maps fleet members', function (): void {
+    Http::fake([
+        'esi.evetech.net/fleets/1/members/' => Http::response([
+            [
+                'character_id' => 90000001,
+                'join_time' => '2026-06-09T12:00:00Z',
+                'role' => 'squad_member',
+                'role_name' => 'string',
+                'ship_type_id' => 2,
+                'solar_system_id' => 3,
+                'squad_id' => 4,
+                'station_id' => 5,
+                'takes_fleet_warp' => true,
+                'wing_id' => 6,
+            ],
+        ]),
+    ]);
+
+    $result = (new Esi)->getFleetMembers(fakeCharacter(), 1);
+
+    expect($result->wasSuccessful())->toBeTrue()
+        ->and($result->data)->toHaveCount(1)
+        ->and($result->data[0])->toBeInstanceOf(FleetMember::class)
+        ->and($result->data[0]->character_id)->toBe(90000001)
+        ->and($result->data[0]->join_time)->toBe('2026-06-09T12:00:00Z')
+        ->and($result->data[0]->role)->toBe('squad_member')
+        ->and($result->data[0]->role_name)->toBe('string')
+        ->and($result->data[0]->ship_type_id)->toBe(2)
+        ->and($result->data[0]->solar_system_id)->toBe(3)
+        ->and($result->data[0]->squad_id)->toBe(4)
+        ->and($result->data[0]->station_id)->toBe(5)
+        ->and($result->data[0]->takes_fleet_warp)->toBeTrue()
+        ->and($result->data[0]->wing_id)->toBe(6);
+});
+
+it('fetches and maps fleet members without a station id', function (): void {
+    Http::fake([
+        'esi.evetech.net/fleets/1/members/' => Http::response([
+            [
+                'character_id' => 90000001,
+                'join_time' => '2026-06-09T12:00:00Z',
+                'role' => 'squad_member',
+                'role_name' => 'string',
+                'ship_type_id' => 2,
+                'solar_system_id' => 3,
+                'squad_id' => 4,
+                'takes_fleet_warp' => false,
+                'wing_id' => 6,
+            ],
+        ]),
+    ]);
+
+    $result = (new Esi)->getFleetMembers(fakeCharacter(), 1);
+
+    expect($result->wasSuccessful())->toBeTrue()
+        ->and($result->data[0]->station_id)->toBeNull()
+        ->and($result->data[0]->takes_fleet_warp)->toBeFalse();
+});
+
+it('fetches and maps fleet wings with nested squads', function (): void {
+    Http::fake([
+        'esi.evetech.net/fleets/1/wings/' => Http::response([
+            [
+                'id' => 90000001,
+                'name' => 'Wing 1',
+                'squads' => [
+                    ['id' => 90000002, 'name' => 'Squad 1'],
+                ],
+            ],
+        ]),
+    ]);
+
+    $result = (new Esi)->getFleetWings(fakeCharacter(), 1);
+
+    expect($result->wasSuccessful())->toBeTrue()
+        ->and($result->data)->toHaveCount(1)
+        ->and($result->data[0])->toBeInstanceOf(FleetWing::class)
+        ->and($result->data[0]->id)->toBe(90000001)
+        ->and($result->data[0]->name)->toBe('Wing 1')
+        ->and($result->data[0]->squads)->toHaveCount(1)
+        ->and($result->data[0]->squads[0]->id)->toBe(90000002)
+        ->and($result->data[0]->squads[0]->name)->toBe('Squad 1');
+});
+
+it('updates a fleet with only the provided fields', function (): void {
+    Http::fake([
+        'esi.evetech.net/fleets/1/' => Http::response(null, 204),
+    ]);
+
+    $result = (new Esi)->updateFleet(fakeCharacter(), 1, true, 'New MOTD');
+
+    expect($result->wasSuccessful())->toBeTrue()
+        ->and($result->data)->toBeNull();
+
+    Http::assertSent(fn ($request) => $request->method() === 'PUT'
+        && str_contains($request->url(), '/fleets/1/')
+        && $request->data() === [
+            'is_free_move' => true,
+            'motd' => 'New MOTD',
+        ]);
+});
+
+it('updates a fleet omitting null fields', function (): void {
+    Http::fake([
+        'esi.evetech.net/fleets/1/' => Http::response(null, 204),
+    ]);
+
+    $result = (new Esi)->updateFleet(fakeCharacter(), 1);
+
+    expect($result->wasSuccessful())->toBeTrue();
+
+    Http::assertSent(fn ($request) => $request->method() === 'PUT'
+        && str_contains($request->url(), '/fleets/1/')
+        && $request->data() === []);
+});
+
+it('invites a fleet member', function (): void {
+    Http::fake([
+        'esi.evetech.net/fleets/1/members/' => Http::response(null, 204),
+    ]);
+
+    $result = (new Esi)->inviteFleetMember(fakeCharacter(), 1, 90000001, 'squad_member', 2, 3);
+
+    expect($result->wasSuccessful())->toBeTrue();
+
+    Http::assertSent(fn ($request) => $request->method() === 'POST'
+        && str_contains($request->url(), '/fleets/1/members/')
+        && $request->data() === [
+            'character_id' => 90000001,
+            'role' => 'squad_member',
+            'squad_id' => 2,
+            'wing_id' => 3,
+        ]);
+});
+
+it('invites a fleet member without optional squad and wing', function (): void {
+    Http::fake([
+        'esi.evetech.net/fleets/1/members/' => Http::response(null, 204),
+    ]);
+
+    $result = (new Esi)->inviteFleetMember(fakeCharacter(), 1, 90000001, 'fleet_commander');
+
+    expect($result->wasSuccessful())->toBeTrue();
+
+    Http::assertSent(fn ($request) => $request->method() === 'POST'
+        && $request->data() === [
+            'character_id' => 90000001,
+            'role' => 'fleet_commander',
+        ]);
+});
+
+it('kicks a fleet member', function (): void {
+    Http::fake([
+        'esi.evetech.net/fleets/1/members/90000001/' => Http::response(null, 204),
+    ]);
+
+    $result = (new Esi)->kickFleetMember(fakeCharacter(), 1, 90000001);
+
+    expect($result->wasSuccessful())->toBeTrue();
+
+    Http::assertSent(fn ($request) => $request->method() === 'DELETE'
+        && str_contains($request->url(), '/fleets/1/members/90000001/'));
+});
+
+it('moves a fleet member', function (): void {
+    Http::fake([
+        'esi.evetech.net/fleets/1/members/90000001/' => Http::response(null, 204),
+    ]);
+
+    $result = (new Esi)->moveFleetMember(fakeCharacter(), 1, 90000001, 'squad_commander', 2, 3);
+
+    expect($result->wasSuccessful())->toBeTrue();
+
+    Http::assertSent(fn ($request) => $request->method() === 'PUT'
+        && str_contains($request->url(), '/fleets/1/members/90000001/')
+        && $request->data() === [
+            'role' => 'squad_commander',
+            'squad_id' => 2,
+            'wing_id' => 3,
+        ]);
+});
+
+it('moves a fleet member without optional squad and wing', function (): void {
+    Http::fake([
+        'esi.evetech.net/fleets/1/members/90000001/' => Http::response(null, 204),
+    ]);
+
+    $result = (new Esi)->moveFleetMember(fakeCharacter(), 1, 90000001, 'fleet_commander');
+
+    expect($result->wasSuccessful())->toBeTrue();
+
+    Http::assertSent(fn ($request) => $request->data() === [
+        'role' => 'fleet_commander',
+    ]);
+});
+
+it('creates a fleet wing and returns the new wing id', function (): void {
+    Http::fake([
+        'esi.evetech.net/fleets/1/wings/' => Http::response(['wing_id' => 90000005], 201),
+    ]);
+
+    $result = (new Esi)->createFleetWing(fakeCharacter(), 1);
+
+    expect($result->wasSuccessful())->toBeTrue()
+        ->and($result->data)->toBe(90000005);
+
+    Http::assertSent(fn ($request) => $request->method() === 'POST'
+        && str_contains($request->url(), '/fleets/1/wings/'));
+});
+
+it('deletes a fleet wing', function (): void {
+    Http::fake([
+        'esi.evetech.net/fleets/1/wings/90000005/' => Http::response(null, 204),
+    ]);
+
+    $result = (new Esi)->deleteFleetWing(fakeCharacter(), 1, 90000005);
+
+    expect($result->wasSuccessful())->toBeTrue();
+
+    Http::assertSent(fn ($request) => $request->method() === 'DELETE'
+        && str_contains($request->url(), '/fleets/1/wings/90000005/'));
+});
+
+it('renames a fleet wing', function (): void {
+    Http::fake([
+        'esi.evetech.net/fleets/1/wings/90000005/' => Http::response(null, 204),
+    ]);
+
+    $result = (new Esi)->renameFleetWing(fakeCharacter(), 1, 90000005, 'Interceptors');
+
+    expect($result->wasSuccessful())->toBeTrue();
+
+    Http::assertSent(fn ($request) => $request->method() === 'PUT'
+        && str_contains($request->url(), '/fleets/1/wings/90000005/')
+        && $request->data() === ['name' => 'Interceptors']);
+});
+
+it('creates a fleet squad and returns the new squad id', function (): void {
+    Http::fake([
+        'esi.evetech.net/fleets/1/wings/90000005/squads/' => Http::response(['squad_id' => 90000006], 201),
+    ]);
+
+    $result = (new Esi)->createFleetSquad(fakeCharacter(), 1, 90000005);
+
+    expect($result->wasSuccessful())->toBeTrue()
+        ->and($result->data)->toBe(90000006);
+
+    Http::assertSent(fn ($request) => $request->method() === 'POST'
+        && str_contains($request->url(), '/fleets/1/wings/90000005/squads/'));
+});
+
+it('deletes a fleet squad', function (): void {
+    Http::fake([
+        'esi.evetech.net/fleets/1/squads/90000006/' => Http::response(null, 204),
+    ]);
+
+    $result = (new Esi)->deleteFleetSquad(fakeCharacter(), 1, 90000006);
+
+    expect($result->wasSuccessful())->toBeTrue();
+
+    Http::assertSent(fn ($request) => $request->method() === 'DELETE'
+        && str_contains($request->url(), '/fleets/1/squads/90000006/'));
+});
+
+it('renames a fleet squad', function (): void {
+    Http::fake([
+        'esi.evetech.net/fleets/1/squads/90000006/' => Http::response(null, 204),
+    ]);
+
+    $result = (new Esi)->renameFleetSquad(fakeCharacter(), 1, 90000006, 'Bombers');
+
+    expect($result->wasSuccessful())->toBeTrue();
+
+    Http::assertSent(fn ($request) => $request->method() === 'PUT'
+        && str_contains($request->url(), '/fleets/1/squads/90000006/')
+        && $request->data() === ['name' => 'Bombers']);
+});
+
+it('returns an error result when a fleet endpoint fails with a server error', function (): void {
+    Http::fake([
+        'esi.evetech.net/fleets/1/' => Http::response(['error' => 'Internal server error'], 500),
+    ]);
+
+    $result = (new Esi)->getFleet(fakeCharacter(), 1);
+
+    expect($result->failed())->toBeTrue()
+        ->and($result->error?->code)->toBe(500);
+});
+
+it('never retries fleet member and wing/squad creation or deletion requests', function (): void {
+    $serverError = new Response(new Psr7Response(500));
+
+    expect((new InviteFleetMemberRequest(1, 2, 'squad_member'))->shouldRetry($serverError))->toBeFalse()
+        ->and((new KickFleetMemberRequest(1, 2))->shouldRetry($serverError))->toBeFalse()
+        ->and((new CreateFleetWingRequest(1))->shouldRetry($serverError))->toBeFalse()
+        ->and((new DeleteFleetWingRequest(1, 2))->shouldRetry($serverError))->toBeFalse()
+        ->and((new CreateFleetSquadRequest(1, 2))->shouldRetry($serverError))->toBeFalse()
+        ->and((new DeleteFleetSquadRequest(1, 2))->shouldRetry($serverError))->toBeFalse();
+});
+
+it('always retries fleet and member/wing/squad state-setting requests', function (): void {
+    $serverError = new Response(new Psr7Response(500));
+
+    expect((new UpdateFleetRequest(1))->shouldRetry($serverError))->toBeTrue()
+        ->and((new MoveFleetMemberRequest(1, 2, 'squad_member'))->shouldRetry($serverError))->toBeTrue()
+        ->and((new RenameFleetWingRequest(1, 2, 'name'))->shouldRetry($serverError))->toBeTrue()
+        ->and((new RenameFleetSquadRequest(1, 2, 'name'))->shouldRetry($serverError))->toBeTrue();
+});


### PR DESCRIPTION
Fleets domain (14 endpoints) — reads (character fleet, fleet, members, wings) and full write CRUD for members/wings/squads. 5 DTOs, 2 new scopes. PHPStan level 9 clean, 100% coverage (229 tests).