### PR TITLE
feat: add mail labels, mailing lists and delete endpoints

### DIFF
--- a/src/DTO/MailLabel.php
+++ b/src/DTO/MailLabel.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\DTO;
+
+use NicolasKion\Esi\Support\Data;
+
+readonly class MailLabel extends Dto
+{
+    public function __construct(
+        public int $label_id,
+        public ?string $name,
+        public ?string $color,
+        public ?int $unread_count,
+    ) {}
+
+    public static function fromData(Data $data): self
+    {
+        return new self(
+            label_id: $data->integer('label_id', 0),
+            name: $data->string('name'),
+            color: $data->string('color'),
+            unread_count: $data->integer('unread_count'),
+        );
+    }
+}

--- a/src/DTO/MailLabels.php
+++ b/src/DTO/MailLabels.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\DTO;
+
+use NicolasKion\Esi\Support\Data;
+
+readonly class MailLabels extends Dto
+{
+    /**
+     * @param  array<int, MailLabel>  $labels
+     */
+    public function __construct(
+        public array $labels,
+        public ?int $total_unread_count,
+    ) {}
+
+    public static function fromData(Data $data): self
+    {
+        return new self(
+            labels: $data->list('labels', MailLabel::fromData(...)),
+            total_unread_count: $data->integer('total_unread_count'),
+        );
+    }
+}

--- a/src/DTO/MailingList.php
+++ b/src/DTO/MailingList.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\DTO;
+
+use NicolasKion\Esi\Support\Data;
+
+readonly class MailingList extends Dto
+{
+    public function __construct(
+        public int $mailing_list_id,
+        public string $name,
+    ) {}
+
+    public static function fromData(Data $data): self
+    {
+        return new self(
+            mailing_list_id: $data->integer('mailing_list_id', 0),
+            name: $data->string('name', ''),
+        );
+    }
+}

--- a/src/Esi.php
+++ b/src/Esi.php
@@ -66,6 +66,8 @@ use NicolasKion\Esi\DTO\JumpFatigue;
 use NicolasKion\Esi\DTO\Killmail;
 use NicolasKion\Esi\DTO\Location;
 use NicolasKion\Esi\DTO\LoyaltyOffer;
+use NicolasKion\Esi\DTO\MailingList;
+use NicolasKion\Esi\DTO\MailLabels;
 use NicolasKion\Esi\DTO\MarketGroup;
 use NicolasKion\Esi\DTO\MarketHistory;
 use NicolasKion\Esi\DTO\MarketOrder;
@@ -114,9 +116,12 @@ use NicolasKion\Esi\Interfaces\Character;
 use NicolasKion\Esi\Requests\AddCharacterContactsRequest;
 use NicolasKion\Esi\Requests\CreateFleetSquadRequest;
 use NicolasKion\Esi\Requests\CreateFleetWingRequest;
+use NicolasKion\Esi\Requests\CreateMailLabelRequest;
 use NicolasKion\Esi\Requests\DeleteCharacterContactsRequest;
 use NicolasKion\Esi\Requests\DeleteFleetSquadRequest;
 use NicolasKion\Esi\Requests\DeleteFleetWingRequest;
+use NicolasKion\Esi\Requests\DeleteMailLabelRequest;
+use NicolasKion\Esi\Requests\DeleteMailRequest;
 use NicolasKion\Esi\Requests\EditCharacterContactsRequest;
 use NicolasKion\Esi\Requests\GetAffiliationsRequest;
 use NicolasKion\Esi\Requests\GetAgentsResearchRequest;
@@ -208,6 +213,8 @@ use NicolasKion\Esi\Requests\GetInsurancePricesRequest;
 use NicolasKion\Esi\Requests\GetKillmailRequest;
 use NicolasKion\Esi\Requests\GetLocationRequest;
 use NicolasKion\Esi\Requests\GetLoyaltyOffersRequest;
+use NicolasKion\Esi\Requests\GetMailingListsRequest;
+use NicolasKion\Esi\Requests\GetMailLabelsRequest;
 use NicolasKion\Esi\Requests\GetMarketGroupRequest;
 use NicolasKion\Esi\Requests\GetMarketGroupsRequest;
 use NicolasKion\Esi\Requests\GetMarketHistoryRequest;
@@ -1034,6 +1041,71 @@ class Esi
     {
         $connector = $this->getAuthenticatedConnector($character, EsiScope::OrganizeMail);
         $request = new UpdateEveMailRequest($character->getId(), $mail_id, $read, $labels);
+
+        return $connector->send($request);
+    }
+
+    /**
+     * Retrieves the mail labels and unread counts for a given character.
+     *
+     * @return EsiResult<MailLabels>
+     */
+    public function getMailLabels(Character $character): EsiResult
+    {
+        $connector = $this->getAuthenticatedConnector($character, EsiScope::ReadMail);
+        $request = new GetMailLabelsRequest($character->getId());
+
+        return $connector->send($request);
+    }
+
+    /**
+     * Retrieves the mailing lists a given character is subscribed to.
+     *
+     * @return EsiResult<array<int, MailingList>>
+     */
+    public function getMailingLists(Character $character): EsiResult
+    {
+        $connector = $this->getAuthenticatedConnector($character, EsiScope::ReadMail);
+        $request = new GetMailingListsRequest($character->getId());
+
+        return $connector->send($request);
+    }
+
+    /**
+     * Creates a mail label for a given character.
+     *
+     * @return EsiResult<int> Returns an instance of EsiResult that contains the new label's ID.
+     */
+    public function createMailLabel(Character $character, string $name, ?string $color = null): EsiResult
+    {
+        $connector = $this->getAuthenticatedConnector($character, EsiScope::OrganizeMail);
+        $request = new CreateMailLabelRequest($character->getId(), $name, $color);
+
+        return $connector->send($request);
+    }
+
+    /**
+     * Deletes a mail label for a given character.
+     *
+     * @return EsiResult<null>
+     */
+    public function deleteMailLabel(Character $character, int $label_id): EsiResult
+    {
+        $connector = $this->getAuthenticatedConnector($character, EsiScope::OrganizeMail);
+        $request = new DeleteMailLabelRequest($character->getId(), $label_id);
+
+        return $connector->send($request);
+    }
+
+    /**
+     * Deletes a mail for a given character.
+     *
+     * @return EsiResult<null>
+     */
+    public function deleteMail(Character $character, int $mail_id): EsiResult
+    {
+        $connector = $this->getAuthenticatedConnector($character, EsiScope::OrganizeMail);
+        $request = new DeleteMailRequest($character->getId(), $mail_id);
 
         return $connector->send($request);
     }

--- a/src/Requests/CreateMailLabelRequest.php
+++ b/src/Requests/CreateMailLabelRequest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\Requests;
+
+use Illuminate\Http\Client\Response;
+use NicolasKion\Esi\Enums\RequestMethod;
+use NicolasKion\Esi\Interfaces\WithBody;
+use NicolasKion\Esi\Request;
+
+/**
+ * @extends Request<int>
+ */
+class CreateMailLabelRequest extends Request implements WithBody
+{
+    public function __construct(
+        public int $character_id,
+        public string $name,
+        public ?string $color = null,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getBody(): array
+    {
+        $data = [
+            'name' => $this->name,
+        ];
+
+        if ($this->color !== null) {
+            $data['color'] = $this->color;
+        }
+
+        return $data;
+    }
+
+    public function resolveEndpoint(): string
+    {
+        return sprintf('/characters/%d/mail/labels/', $this->character_id);
+    }
+
+    public function getMethod(): RequestMethod
+    {
+        return RequestMethod::POST;
+    }
+
+    public function createDto(Response $response, mixed $data): int
+    {
+        return is_numeric($data) ? (int) $data : 0;
+    }
+
+    public function shouldRetry(Response $response): bool
+    {
+        return false;
+    }
+}

--- a/src/Requests/DeleteMailLabelRequest.php
+++ b/src/Requests/DeleteMailLabelRequest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\Requests;
+
+use Illuminate\Http\Client\Response;
+use NicolasKion\Esi\Enums\RequestMethod;
+use NicolasKion\Esi\Request;
+
+/**
+ * @extends Request<null>
+ */
+class DeleteMailLabelRequest extends Request
+{
+    public function __construct(
+        public int $character_id,
+        public int $label_id,
+    ) {}
+
+    public function resolveEndpoint(): string
+    {
+        return sprintf('/characters/%d/mail/labels/%d/', $this->character_id, $this->label_id);
+    }
+
+    public function getMethod(): RequestMethod
+    {
+        return RequestMethod::DELETE;
+    }
+
+    public function createDto(Response $response, mixed $data): null
+    {
+        return null;
+    }
+
+    public function shouldRetry(Response $response): bool
+    {
+        return false;
+    }
+}

--- a/src/Requests/DeleteMailRequest.php
+++ b/src/Requests/DeleteMailRequest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\Requests;
+
+use Illuminate\Http\Client\Response;
+use NicolasKion\Esi\Enums\RequestMethod;
+use NicolasKion\Esi\Request;
+
+/**
+ * @extends Request<null>
+ */
+class DeleteMailRequest extends Request
+{
+    public function __construct(
+        public int $character_id,
+        public int $mail_id,
+    ) {}
+
+    public function resolveEndpoint(): string
+    {
+        return sprintf('/characters/%d/mail/%d/', $this->character_id, $this->mail_id);
+    }
+
+    public function getMethod(): RequestMethod
+    {
+        return RequestMethod::DELETE;
+    }
+
+    public function createDto(Response $response, mixed $data): null
+    {
+        return null;
+    }
+
+    public function shouldRetry(Response $response): bool
+    {
+        return false;
+    }
+}

--- a/src/Requests/GetMailLabelsRequest.php
+++ b/src/Requests/GetMailLabelsRequest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\Requests;
+
+use Illuminate\Http\Client\Response;
+use NicolasKion\Esi\DTO\MailLabels;
+use NicolasKion\Esi\Request;
+
+/**
+ * @extends Request<MailLabels>
+ */
+class GetMailLabelsRequest extends Request
+{
+    public function __construct(
+        public int $character_id
+    ) {
+        //
+    }
+
+    public function resolveEndpoint(): string
+    {
+        return sprintf('/characters/%d/mail/labels/', $this->character_id);
+    }
+
+    public function createDto(Response $response, mixed $data): MailLabels
+    {
+        return MailLabels::hydrate($data);
+    }
+}

--- a/src/Requests/GetMailingListsRequest.php
+++ b/src/Requests/GetMailingListsRequest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\Requests;
+
+use Illuminate\Http\Client\Response;
+use NicolasKion\Esi\DTO\MailingList;
+use NicolasKion\Esi\Request;
+
+/**
+ * @extends Request<array<int, MailingList>>
+ */
+class GetMailingListsRequest extends Request
+{
+    public function __construct(
+        public int $character_id
+    ) {
+        //
+    }
+
+    public function resolveEndpoint(): string
+    {
+        return sprintf('/characters/%d/mail/lists/', $this->character_id);
+    }
+
+    /**
+     * @return array<int, MailingList>
+     */
+    public function createDto(Response $response, mixed $data): array
+    {
+        return MailingList::hydrateList($data);
+    }
+}

--- a/tests/Fixtures/mail/labels.json
+++ b/tests/Fixtures/mail/labels.json
@@ -1,0 +1,11 @@
+{
+    "labels": [
+        {
+            "color": "#0000fe",
+            "label_id": 90000001,
+            "name": "string",
+            "unread_count": 90000001
+        }
+    ],
+    "total_unread_count": 90000001
+}

--- a/tests/Fixtures/mail/lists.json
+++ b/tests/Fixtures/mail/lists.json
@@ -1,0 +1,6 @@
+[
+    {
+        "mailing_list_id": 90000001,
+        "name": "string"
+    }
+]

--- a/tests/MailExtraTest.php
+++ b/tests/MailExtraTest.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Http;
+use NicolasKion\Esi\DTO\MailingList;
+use NicolasKion\Esi\DTO\MailLabel;
+use NicolasKion\Esi\DTO\MailLabels;
+use NicolasKion\Esi\Esi;
+
+it('fetches and maps mail labels', function (): void {
+    Http::fake([
+        'esi.evetech.net/characters/123/mail/labels/' => Http::response(esiFixture('mail/labels.json')),
+    ]);
+
+    $result = (new Esi)->getMailLabels(fakeCharacter());
+
+    expect($result->wasSuccessful())->toBeTrue()
+        ->and($result->data)->toBeInstanceOf(MailLabels::class)
+        ->and($result->data->total_unread_count)->toBe(90000001)
+        ->and($result->data->labels)->toHaveCount(1)
+        ->and($result->data->labels[0])->toBeInstanceOf(MailLabel::class)
+        ->and($result->data->labels[0]->label_id)->toBe(90000001)
+        ->and($result->data->labels[0]->name)->toBe('string')
+        ->and($result->data->labels[0]->color)->toBe('#0000fe')
+        ->and($result->data->labels[0]->unread_count)->toBe(90000001);
+});
+
+it('fetches and maps mailing lists', function (): void {
+    Http::fake([
+        'esi.evetech.net/characters/123/mail/lists/' => Http::response(esiFixture('mail/lists.json')),
+    ]);
+
+    $result = (new Esi)->getMailingLists(fakeCharacter());
+
+    expect($result->wasSuccessful())->toBeTrue()
+        ->and($result->data)->toHaveCount(1)
+        ->and($result->data[0])->toBeInstanceOf(MailingList::class)
+        ->and($result->data[0]->mailing_list_id)->toBe(90000001)
+        ->and($result->data[0]->name)->toBe('string');
+});
+
+it('creates a mail label and returns the new label id', function (): void {
+    Http::fake([
+        'esi.evetech.net/characters/123/mail/labels/' => Http::response('42', 201, ['Content-Type' => 'application/json']),
+    ]);
+
+    $result = (new Esi)->createMailLabel(fakeCharacter(), 'Important', '#ffffff');
+
+    expect($result->wasSuccessful())->toBeTrue()
+        ->and($result->data)->toBe(42);
+
+    Http::assertSent(fn ($request) => $request->method() === 'POST'
+        && str_contains($request->url(), '/characters/123/mail/labels/')
+        && $request->data() === [
+            'name' => 'Important',
+            'color' => '#ffffff',
+        ]);
+});
+
+it('creates a mail label without a color', function (): void {
+    Http::fake([
+        'esi.evetech.net/characters/123/mail/labels/' => Http::response('42', 201, ['Content-Type' => 'application/json']),
+    ]);
+
+    $result = (new Esi)->createMailLabel(fakeCharacter(), 'Important');
+
+    expect($result->wasSuccessful())->toBeTrue()
+        ->and($result->data)->toBe(42);
+
+    Http::assertSent(fn ($request) => $request->method() === 'POST'
+        && str_contains($request->url(), '/characters/123/mail/labels/')
+        && $request->data() === [
+            'name' => 'Important',
+        ]);
+});
+
+it('deletes a mail label', function (): void {
+    Http::fake([
+        'esi.evetech.net/characters/123/mail/labels/1/' => Http::response(null, 204),
+    ]);
+
+    $result = (new Esi)->deleteMailLabel(fakeCharacter(), 1);
+
+    expect($result->wasSuccessful())->toBeTrue()
+        ->and($result->data)->toBeNull();
+
+    Http::assertSent(fn ($request) => $request->method() === 'DELETE'
+        && str_contains($request->url(), '/characters/123/mail/labels/1/'));
+});
+
+it('deletes a mail', function (): void {
+    Http::fake([
+        'esi.evetech.net/characters/123/mail/987654/' => Http::response(null, 204),
+    ]);
+
+    $result = (new Esi)->deleteMail(fakeCharacter(), 987654);
+
+    expect($result->wasSuccessful())->toBeTrue()
+        ->and($result->data)->toBeNull();
+
+    Http::assertSent(fn ($request) => $request->method() === 'DELETE'
+        && str_contains($request->url(), '/characters/123/mail/987654/'));
+});
+
+it('returns an error result when the mail labels endpoint fails', function (): void {
+    Http::fake([
+        'esi.evetech.net/characters/123/mail/labels/' => Http::response(['error' => 'Internal server error'], 500),
+    ]);
+
+    $result = (new Esi)->getMailLabels(fakeCharacter());
+
+    expect($result->failed())->toBeTrue()
+        ->and($result->error?->code)->toBe(500);
+});
+
+it('returns an error result when creating a mail label fails', function (): void {
+    Http::fake([
+        'esi.evetech.net/characters/123/mail/labels/' => Http::response(['error' => 'Internal server error'], 500),
+    ]);
+
+    $result = (new Esi)->createMailLabel(fakeCharacter(), 'Important');
+
+    expect($result->failed())->toBeTrue()
+        ->and($result->error?->code)->toBe(500);
+});
+
+it('returns an error result when deleting a mail label fails', function (): void {
+    Http::fake([
+        'esi.evetech.net/characters/123/mail/labels/1/' => Http::response(['error' => 'Internal server error'], 500),
+    ]);
+
+    $result = (new Esi)->deleteMailLabel(fakeCharacter(), 1);
+
+    expect($result->failed())->toBeTrue()
+        ->and($result->error?->code)->toBe(500);
+});
+
+it('returns an error result when deleting a mail fails', function (): void {
+    Http::fake([
+        'esi.evetech.net/characters/123/mail/987654/' => Http::response(['error' => 'Internal server error'], 500),
+    ]);
+
+    $result = (new Esi)->deleteMail(fakeCharacter(), 987654);
+
+    expect($result->failed())->toBeTrue()
+        ->and($result->error?->code)->toBe(500);
+});


### PR DESCRIPTION
Completes the Mail domain: labels (get/create/delete), mailing lists, and mail deletion. 3 DTOs, 5 requests, no new scopes. PHPStan level 9 clean, 100% coverage (239 tests).