### PR TITLE
feat: add industry endpoints

### DIFF
--- a/src/DTO/IndustryFacility.php
+++ b/src/DTO/IndustryFacility.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\DTO;
+
+use NicolasKion\Esi\Support\Data;
+
+readonly class IndustryFacility extends Dto
+{
+    public function __construct(
+        public int $facility_id,
+        public int $owner_id,
+        public int $region_id,
+        public int $solar_system_id,
+        public ?float $tax,
+        public int $type_id,
+    ) {}
+
+    public static function fromData(Data $data): self
+    {
+        return new self(
+            facility_id: $data->integer('facility_id', 0),
+            owner_id: $data->integer('owner_id', 0),
+            region_id: $data->integer('region_id', 0),
+            solar_system_id: $data->integer('solar_system_id', 0),
+            tax: $data->float('tax'),
+            type_id: $data->integer('type_id', 0),
+        );
+    }
+}

--- a/src/DTO/IndustryJob.php
+++ b/src/DTO/IndustryJob.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\DTO;
+
+use NicolasKion\Esi\Support\Data;
+
+readonly class IndustryJob extends Dto
+{
+    public function __construct(
+        public int $job_id,
+        public int $installer_id,
+        public int $facility_id,
+        public int $activity_id,
+        public int $blueprint_id,
+        public int $blueprint_type_id,
+        public int $blueprint_location_id,
+        public int $output_location_id,
+        public int $runs,
+        public string $status,
+        public string $start_date,
+        public string $end_date,
+        public int $duration,
+        public ?float $cost,
+        public ?int $licensed_runs,
+        public ?float $probability,
+        public ?int $product_type_id,
+        public ?int $completed_character_id,
+        public ?string $completed_date,
+        public ?string $pause_date,
+        public ?int $successful_runs,
+        public ?int $station_id,
+        public ?int $location_id,
+    ) {}
+
+    public static function fromData(Data $data): self
+    {
+        return new self(
+            job_id: $data->integer('job_id', 0),
+            installer_id: $data->integer('installer_id', 0),
+            facility_id: $data->integer('facility_id', 0),
+            activity_id: $data->integer('activity_id', 0),
+            blueprint_id: $data->integer('blueprint_id', 0),
+            blueprint_type_id: $data->integer('blueprint_type_id', 0),
+            blueprint_location_id: $data->integer('blueprint_location_id', 0),
+            output_location_id: $data->integer('output_location_id', 0),
+            runs: $data->integer('runs', 0),
+            status: $data->string('status', ''),
+            start_date: $data->string('start_date', ''),
+            end_date: $data->string('end_date', ''),
+            duration: $data->integer('duration', 0),
+            cost: $data->float('cost'),
+            licensed_runs: $data->integer('licensed_runs'),
+            probability: $data->float('probability'),
+            product_type_id: $data->integer('product_type_id'),
+            completed_character_id: $data->integer('completed_character_id'),
+            completed_date: $data->string('completed_date'),
+            pause_date: $data->string('pause_date'),
+            successful_runs: $data->integer('successful_runs'),
+            station_id: $data->integer('station_id'),
+            location_id: $data->integer('location_id'),
+        );
+    }
+}

--- a/src/DTO/IndustrySystem.php
+++ b/src/DTO/IndustrySystem.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\DTO;
+
+use NicolasKion\Esi\Support\Data;
+
+readonly class IndustrySystem extends Dto
+{
+    /**
+     * @param  array<int, SystemCostIndex>  $cost_indices
+     */
+    public function __construct(
+        public int $solar_system_id,
+        public array $cost_indices,
+    ) {}
+
+    public static function fromData(Data $data): self
+    {
+        return new self(
+            solar_system_id: $data->integer('solar_system_id', 0),
+            cost_indices: $data->list('cost_indices', SystemCostIndex::fromData(...)),
+        );
+    }
+}

--- a/src/DTO/MiningExtraction.php
+++ b/src/DTO/MiningExtraction.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\DTO;
+
+use NicolasKion\Esi\Support\Data;
+
+readonly class MiningExtraction extends Dto
+{
+    public function __construct(
+        public int $structure_id,
+        public int $moon_id,
+        public string $extraction_start_time,
+        public string $chunk_arrival_time,
+        public string $natural_decay_time,
+    ) {}
+
+    public static function fromData(Data $data): self
+    {
+        return new self(
+            structure_id: $data->integer('structure_id', 0),
+            moon_id: $data->integer('moon_id', 0),
+            extraction_start_time: $data->string('extraction_start_time', ''),
+            chunk_arrival_time: $data->string('chunk_arrival_time', ''),
+            natural_decay_time: $data->string('natural_decay_time', ''),
+        );
+    }
+}

--- a/src/DTO/MiningLedgerEntry.php
+++ b/src/DTO/MiningLedgerEntry.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\DTO;
+
+use NicolasKion\Esi\Support\Data;
+
+readonly class MiningLedgerEntry extends Dto
+{
+    public function __construct(
+        public string $date,
+        public int $quantity,
+        public int $solar_system_id,
+        public int $type_id,
+    ) {}
+
+    public static function fromData(Data $data): self
+    {
+        return new self(
+            date: $data->string('date', ''),
+            quantity: $data->integer('quantity', 0),
+            solar_system_id: $data->integer('solar_system_id', 0),
+            type_id: $data->integer('type_id', 0),
+        );
+    }
+}

--- a/src/DTO/MiningObserver.php
+++ b/src/DTO/MiningObserver.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\DTO;
+
+use NicolasKion\Esi\Support\Data;
+
+readonly class MiningObserver extends Dto
+{
+    public function __construct(
+        public string $last_updated,
+        public int $observer_id,
+        public string $observer_type,
+    ) {}
+
+    public static function fromData(Data $data): self
+    {
+        return new self(
+            last_updated: $data->string('last_updated', ''),
+            observer_id: $data->integer('observer_id', 0),
+            observer_type: $data->string('observer_type', ''),
+        );
+    }
+}

--- a/src/DTO/MiningObserverEntry.php
+++ b/src/DTO/MiningObserverEntry.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\DTO;
+
+use NicolasKion\Esi\Support\Data;
+
+readonly class MiningObserverEntry extends Dto
+{
+    public function __construct(
+        public string $last_updated,
+        public int $character_id,
+        public int $recorded_corporation_id,
+        public int $type_id,
+        public int $quantity,
+    ) {}
+
+    public static function fromData(Data $data): self
+    {
+        return new self(
+            last_updated: $data->string('last_updated', ''),
+            character_id: $data->integer('character_id', 0),
+            recorded_corporation_id: $data->integer('recorded_corporation_id', 0),
+            type_id: $data->integer('type_id', 0),
+            quantity: $data->integer('quantity', 0),
+        );
+    }
+}

--- a/src/DTO/SystemCostIndex.php
+++ b/src/DTO/SystemCostIndex.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\DTO;
+
+use NicolasKion\Esi\Support\Data;
+
+readonly class SystemCostIndex extends Dto
+{
+    public function __construct(
+        public string $activity,
+        public float $cost_index,
+    ) {}
+
+    public static function fromData(Data $data): self
+    {
+        return new self(
+            activity: $data->string('activity', ''),
+            cost_index: $data->float('cost_index', 0.0),
+        );
+    }
+}

--- a/src/Enums/EsiScope.php
+++ b/src/Enums/EsiScope.php
@@ -56,6 +56,10 @@ enum EsiScope: string
     case ReadImplants = 'esi-clones.read_implants.v1';
     case ReadFleet = 'esi-fleets.read_fleet.v1';
     case WriteFleet = 'esi-fleets.write_fleet.v1';
+    case ReadCharacterIndustryJobs = 'esi-industry.read_character_jobs.v1';
+    case ReadCharacterMining = 'esi-industry.read_character_mining.v1';
+    case ReadCorporationMining = 'esi-industry.read_corporation_mining.v1';
+    case ReadCorporationIndustryJobs = 'esi-industry.read_corporation_jobs.v1';
 
     /**
      * @return array<int, string>

--- a/src/Esi.php
+++ b/src/Esi.php
@@ -61,6 +61,9 @@ use NicolasKion\Esi\DTO\FleetMember;
 use NicolasKion\Esi\DTO\FleetWing;
 use NicolasKion\Esi\DTO\Graphic;
 use NicolasKion\Esi\DTO\Incursion;
+use NicolasKion\Esi\DTO\IndustryFacility;
+use NicolasKion\Esi\DTO\IndustryJob;
+use NicolasKion\Esi\DTO\IndustrySystem;
 use NicolasKion\Esi\DTO\InsurancePrice;
 use NicolasKion\Esi\DTO\IssuedMedal;
 use NicolasKion\Esi\DTO\JumpFatigue;
@@ -76,6 +79,10 @@ use NicolasKion\Esi\DTO\MarketOrder;
 use NicolasKion\Esi\DTO\MarketPrice;
 use NicolasKion\Esi\DTO\MemberTitles;
 use NicolasKion\Esi\DTO\MemberTracking;
+use NicolasKion\Esi\DTO\MiningExtraction;
+use NicolasKion\Esi\DTO\MiningLedgerEntry;
+use NicolasKion\Esi\DTO\MiningObserver;
+use NicolasKion\Esi\DTO\MiningObserverEntry;
 use NicolasKion\Esi\DTO\Moon;
 use NicolasKion\Esi\DTO\Name;
 use NicolasKion\Esi\DTO\Notification;
@@ -152,7 +159,9 @@ use NicolasKion\Esi\Requests\GetCharacterFactionWarfareStatsRequest;
 use NicolasKion\Esi\Requests\GetCharacterFatigueRequest;
 use NicolasKion\Esi\Requests\GetCharacterFleetRequest;
 use NicolasKion\Esi\Requests\GetCharacterImplantsRequest;
+use NicolasKion\Esi\Requests\GetCharacterIndustryJobsRequest;
 use NicolasKion\Esi\Requests\GetCharacterMedalsRequest;
+use NicolasKion\Esi\Requests\GetCharacterMiningRequest;
 use NicolasKion\Esi\Requests\GetCharacterNotificationsRequest;
 use NicolasKion\Esi\Requests\GetCharacterPortraitRequest;
 use NicolasKion\Esi\Requests\GetCharacterRecentKillmailsRequest;
@@ -177,12 +186,16 @@ use NicolasKion\Esi\Requests\GetCorporationDivisionsRequest;
 use NicolasKion\Esi\Requests\GetCorporationFacilitiesRequest;
 use NicolasKion\Esi\Requests\GetCorporationFactionWarfareStatsRequest;
 use NicolasKion\Esi\Requests\GetCorporationIconsRequest;
+use NicolasKion\Esi\Requests\GetCorporationIndustryJobsRequest;
 use NicolasKion\Esi\Requests\GetCorporationIssuedMedalsRequest;
 use NicolasKion\Esi\Requests\GetCorporationMedalsRequest;
 use NicolasKion\Esi\Requests\GetCorporationMemberLimitRequest;
 use NicolasKion\Esi\Requests\GetCorporationMembersRequest;
 use NicolasKion\Esi\Requests\GetCorporationMemberTitlesRequest;
 use NicolasKion\Esi\Requests\GetCorporationMemberTrackingRequest;
+use NicolasKion\Esi\Requests\GetCorporationMiningExtractionsRequest;
+use NicolasKion\Esi\Requests\GetCorporationMiningObserverRequest;
+use NicolasKion\Esi\Requests\GetCorporationMiningObserversRequest;
 use NicolasKion\Esi\Requests\GetCorporationRecentKillmailsRequest;
 use NicolasKion\Esi\Requests\GetCorporationRequest;
 use NicolasKion\Esi\Requests\GetCorporationRolesHistoryRequest;
@@ -217,6 +230,8 @@ use NicolasKion\Esi\Requests\GetFleetWingsRequest;
 use NicolasKion\Esi\Requests\GetGraphicRequest;
 use NicolasKion\Esi\Requests\GetIdsRequest;
 use NicolasKion\Esi\Requests\GetIncursionsRequest;
+use NicolasKion\Esi\Requests\GetIndustryFacilitiesRequest;
+use NicolasKion\Esi\Requests\GetIndustrySystemsRequest;
 use NicolasKion\Esi\Requests\GetInsurancePricesRequest;
 use NicolasKion\Esi\Requests\GetKillmailRequest;
 use NicolasKion\Esi\Requests\GetLocationRequest;
@@ -2497,6 +2512,110 @@ class Esi
         $request = new RenameFleetSquadRequest($fleet_id, $squad_id, $name);
 
         return $connector->send($request);
+    }
+
+    /**
+     * Retrieves a list of industry facilities.
+     *
+     * @return EsiResult<array<int, IndustryFacility>> Returns an instance of EsiResult that contains the retrieved industry facilities.
+     */
+    public function getIndustryFacilities(): EsiResult
+    {
+        $connector = new Connector;
+        $request = new GetIndustryFacilitiesRequest;
+
+        return $connector->send($request);
+    }
+
+    /**
+     * Retrieves the cost indices for solar systems used in industry.
+     *
+     * @return EsiResult<array<int, IndustrySystem>> Returns an instance of EsiResult that contains the retrieved industry systems.
+     */
+    public function getIndustrySystems(): EsiResult
+    {
+        $connector = new Connector;
+        $request = new GetIndustrySystemsRequest;
+
+        return $connector->send($request);
+    }
+
+    /**
+     * Retrieves the industry jobs for a given character.
+     *
+     * @return EsiResult<array<int, IndustryJob>> Returns an instance of EsiResult that contains the retrieved industry jobs.
+     */
+    public function getCharacterIndustryJobs(Character $character): EsiResult
+    {
+        $connector = $this->getAuthenticatedConnector($character, EsiScope::ReadCharacterIndustryJobs);
+        $request = new GetCharacterIndustryJobsRequest($character->getId());
+
+        return $connector->send($request);
+    }
+
+    /**
+     * Retrieves the industry jobs for a corporation.
+     *
+     * @return EsiResult<array<int, IndustryJob>> Returns an instance of EsiResult that contains the retrieved industry jobs.
+     */
+    public function getCorporationIndustryJobs(Character $character, int $corporation_id): EsiResult
+    {
+        $connector = $this->getAuthenticatedConnector($character, EsiScope::ReadCorporationIndustryJobs);
+        $request = new GetCorporationIndustryJobsRequest($corporation_id);
+
+        return $connector->sendPaginated($request);
+    }
+
+    /**
+     * Retrieves the mining ledger for a given character.
+     *
+     * @return EsiResult<array<int, MiningLedgerEntry>> Returns an instance of EsiResult that contains the retrieved mining ledger.
+     */
+    public function getCharacterMining(Character $character): EsiResult
+    {
+        $connector = $this->getAuthenticatedConnector($character, EsiScope::ReadCharacterMining);
+        $request = new GetCharacterMiningRequest($character->getId());
+
+        return $connector->sendPaginated($request);
+    }
+
+    /**
+     * Retrieves the moon mining extractions for a corporation.
+     *
+     * @return EsiResult<array<int, MiningExtraction>> Returns an instance of EsiResult that contains the retrieved moon mining extractions.
+     */
+    public function getCorporationMiningExtractions(Character $character, int $corporation_id): EsiResult
+    {
+        $connector = $this->getAuthenticatedConnector($character, EsiScope::ReadCorporationMining);
+        $request = new GetCorporationMiningExtractionsRequest($corporation_id);
+
+        return $connector->sendPaginated($request);
+    }
+
+    /**
+     * Retrieves the mining observers for a corporation.
+     *
+     * @return EsiResult<array<int, MiningObserver>> Returns an instance of EsiResult that contains the retrieved mining observers.
+     */
+    public function getCorporationMiningObservers(Character $character, int $corporation_id): EsiResult
+    {
+        $connector = $this->getAuthenticatedConnector($character, EsiScope::ReadCorporationMining);
+        $request = new GetCorporationMiningObserversRequest($corporation_id);
+
+        return $connector->sendPaginated($request);
+    }
+
+    /**
+     * Retrieves the mining ledger observed by a specific mining observer.
+     *
+     * @return EsiResult<array<int, MiningObserverEntry>> Returns an instance of EsiResult that contains the retrieved mining observer entries.
+     */
+    public function getCorporationMiningObserver(Character $character, int $corporation_id, int $observer_id): EsiResult
+    {
+        $connector = $this->getAuthenticatedConnector($character, EsiScope::ReadCorporationMining);
+        $request = new GetCorporationMiningObserverRequest($corporation_id, $observer_id);
+
+        return $connector->sendPaginated($request);
     }
 
     private function getAuthenticatedConnector(Character $character, EsiScope $scope): Connector

--- a/src/Requests/GetCharacterIndustryJobsRequest.php
+++ b/src/Requests/GetCharacterIndustryJobsRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\Requests;
+
+use Illuminate\Http\Client\Response;
+use NicolasKion\Esi\DTO\IndustryJob;
+use NicolasKion\Esi\Request;
+
+/**
+ * @extends Request<array<int, IndustryJob>>
+ */
+class GetCharacterIndustryJobsRequest extends Request
+{
+    public function __construct(public int $character_id) {}
+
+    public function resolveEndpoint(): string
+    {
+        return sprintf('/characters/%d/industry/jobs', $this->character_id);
+    }
+
+    /**
+     * @return array<int, IndustryJob>
+     */
+    public function createDto(Response $response, mixed $data): array
+    {
+        return IndustryJob::hydrateList($data);
+    }
+}

--- a/src/Requests/GetCharacterMiningRequest.php
+++ b/src/Requests/GetCharacterMiningRequest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\Requests;
+
+use Illuminate\Http\Client\Response;
+use NicolasKion\Esi\DTO\MiningLedgerEntry;
+use NicolasKion\Esi\Interfaces\WithPagination;
+use NicolasKion\Esi\Request;
+use NicolasKion\Esi\Traits\BasicPagination;
+
+/**
+ * @extends Request<array<int, MiningLedgerEntry>>
+ *
+ * @implements WithPagination<array<int, MiningLedgerEntry>>
+ */
+class GetCharacterMiningRequest extends Request implements WithPagination
+{
+    use BasicPagination;
+
+    public function __construct(public int $character_id) {}
+
+    public function resolveEndpoint(): string
+    {
+        return sprintf('/characters/%d/mining', $this->character_id);
+    }
+
+    /**
+     * @return array<int, MiningLedgerEntry>
+     */
+    public function createDto(Response $response, mixed $data): array
+    {
+        return MiningLedgerEntry::hydrateList($data);
+    }
+}

--- a/src/Requests/GetCorporationIndustryJobsRequest.php
+++ b/src/Requests/GetCorporationIndustryJobsRequest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\Requests;
+
+use Illuminate\Http\Client\Response;
+use NicolasKion\Esi\DTO\IndustryJob;
+use NicolasKion\Esi\Interfaces\WithPagination;
+use NicolasKion\Esi\Request;
+use NicolasKion\Esi\Traits\BasicPagination;
+
+/**
+ * @extends Request<array<int, IndustryJob>>
+ *
+ * @implements WithPagination<array<int, IndustryJob>>
+ */
+class GetCorporationIndustryJobsRequest extends Request implements WithPagination
+{
+    use BasicPagination;
+
+    public function __construct(public int $corporation_id) {}
+
+    public function resolveEndpoint(): string
+    {
+        return sprintf('/corporations/%d/industry/jobs', $this->corporation_id);
+    }
+
+    /**
+     * @return array<int, IndustryJob>
+     */
+    public function createDto(Response $response, mixed $data): array
+    {
+        return IndustryJob::hydrateList($data);
+    }
+}

--- a/src/Requests/GetCorporationMiningExtractionsRequest.php
+++ b/src/Requests/GetCorporationMiningExtractionsRequest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\Requests;
+
+use Illuminate\Http\Client\Response;
+use NicolasKion\Esi\DTO\MiningExtraction;
+use NicolasKion\Esi\Interfaces\WithPagination;
+use NicolasKion\Esi\Request;
+use NicolasKion\Esi\Traits\BasicPagination;
+
+/**
+ * @extends Request<array<int, MiningExtraction>>
+ *
+ * @implements WithPagination<array<int, MiningExtraction>>
+ */
+class GetCorporationMiningExtractionsRequest extends Request implements WithPagination
+{
+    use BasicPagination;
+
+    public function __construct(public int $corporation_id) {}
+
+    /**
+     * Note: ESI uses the singular "/corporation/" prefix for mining endpoints,
+     * unlike the plural "/corporations/" used elsewhere in the API.
+     */
+    public function resolveEndpoint(): string
+    {
+        return sprintf('/corporation/%d/mining/extractions', $this->corporation_id);
+    }
+
+    /**
+     * @return array<int, MiningExtraction>
+     */
+    public function createDto(Response $response, mixed $data): array
+    {
+        return MiningExtraction::hydrateList($data);
+    }
+}

--- a/src/Requests/GetCorporationMiningObserverRequest.php
+++ b/src/Requests/GetCorporationMiningObserverRequest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\Requests;
+
+use Illuminate\Http\Client\Response;
+use NicolasKion\Esi\DTO\MiningObserverEntry;
+use NicolasKion\Esi\Interfaces\WithPagination;
+use NicolasKion\Esi\Request;
+use NicolasKion\Esi\Traits\BasicPagination;
+
+/**
+ * @extends Request<array<int, MiningObserverEntry>>
+ *
+ * @implements WithPagination<array<int, MiningObserverEntry>>
+ */
+class GetCorporationMiningObserverRequest extends Request implements WithPagination
+{
+    use BasicPagination;
+
+    public function __construct(
+        public int $corporation_id,
+        public int $observer_id,
+    ) {}
+
+    /**
+     * Note: ESI uses the singular "/corporation/" prefix for mining endpoints,
+     * unlike the plural "/corporations/" used elsewhere in the API.
+     */
+    public function resolveEndpoint(): string
+    {
+        return sprintf('/corporation/%d/mining/observers/%d', $this->corporation_id, $this->observer_id);
+    }
+
+    /**
+     * @return array<int, MiningObserverEntry>
+     */
+    public function createDto(Response $response, mixed $data): array
+    {
+        return MiningObserverEntry::hydrateList($data);
+    }
+}

--- a/src/Requests/GetCorporationMiningObserversRequest.php
+++ b/src/Requests/GetCorporationMiningObserversRequest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\Requests;
+
+use Illuminate\Http\Client\Response;
+use NicolasKion\Esi\DTO\MiningObserver;
+use NicolasKion\Esi\Interfaces\WithPagination;
+use NicolasKion\Esi\Request;
+use NicolasKion\Esi\Traits\BasicPagination;
+
+/**
+ * @extends Request<array<int, MiningObserver>>
+ *
+ * @implements WithPagination<array<int, MiningObserver>>
+ */
+class GetCorporationMiningObserversRequest extends Request implements WithPagination
+{
+    use BasicPagination;
+
+    public function __construct(public int $corporation_id) {}
+
+    /**
+     * Note: ESI uses the singular "/corporation/" prefix for mining endpoints,
+     * unlike the plural "/corporations/" used elsewhere in the API.
+     */
+    public function resolveEndpoint(): string
+    {
+        return sprintf('/corporation/%d/mining/observers', $this->corporation_id);
+    }
+
+    /**
+     * @return array<int, MiningObserver>
+     */
+    public function createDto(Response $response, mixed $data): array
+    {
+        return MiningObserver::hydrateList($data);
+    }
+}

--- a/src/Requests/GetIndustryFacilitiesRequest.php
+++ b/src/Requests/GetIndustryFacilitiesRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\Requests;
+
+use Illuminate\Http\Client\Response;
+use NicolasKion\Esi\DTO\IndustryFacility;
+use NicolasKion\Esi\Request;
+
+/**
+ * @extends Request<array<int, IndustryFacility>>
+ */
+class GetIndustryFacilitiesRequest extends Request
+{
+    public function resolveEndpoint(): string
+    {
+        return '/industry/facilities';
+    }
+
+    /**
+     * @return array<int, IndustryFacility>
+     */
+    public function createDto(Response $response, mixed $data): array
+    {
+        return IndustryFacility::hydrateList($data);
+    }
+}

--- a/src/Requests/GetIndustrySystemsRequest.php
+++ b/src/Requests/GetIndustrySystemsRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\Requests;
+
+use Illuminate\Http\Client\Response;
+use NicolasKion\Esi\DTO\IndustrySystem;
+use NicolasKion\Esi\Request;
+
+/**
+ * @extends Request<array<int, IndustrySystem>>
+ */
+class GetIndustrySystemsRequest extends Request
+{
+    public function resolveEndpoint(): string
+    {
+        return '/industry/systems';
+    }
+
+    /**
+     * @return array<int, IndustrySystem>
+     */
+    public function createDto(Response $response, mixed $data): array
+    {
+        return IndustrySystem::hydrateList($data);
+    }
+}

--- a/tests/IndustryTest.php
+++ b/tests/IndustryTest.php
@@ -1,0 +1,302 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Http;
+use NicolasKion\Esi\DTO\IndustryFacility;
+use NicolasKion\Esi\DTO\IndustryJob;
+use NicolasKion\Esi\DTO\IndustrySystem;
+use NicolasKion\Esi\DTO\MiningExtraction;
+use NicolasKion\Esi\DTO\MiningLedgerEntry;
+use NicolasKion\Esi\DTO\MiningObserver;
+use NicolasKion\Esi\DTO\MiningObserverEntry;
+use NicolasKion\Esi\Esi;
+
+it('fetches and maps industry facilities', function (): void {
+    Http::fake([
+        'esi.evetech.net/industry/facilities*' => Http::response([
+            [
+                'facility_id' => 90000001,
+                'owner_id' => 90000002,
+                'region_id' => 90000003,
+                'solar_system_id' => 90000004,
+                'tax' => 1.5,
+                'type_id' => 90000005,
+            ],
+            [
+                'facility_id' => 90000006,
+                'owner_id' => 90000007,
+                'region_id' => 90000008,
+                'solar_system_id' => 90000009,
+                'type_id' => 90000010,
+            ],
+        ]),
+    ]);
+
+    $result = (new Esi)->getIndustryFacilities();
+
+    expect($result->wasSuccessful())->toBeTrue()
+        ->and($result->data)->toHaveCount(2)
+        ->and($result->data[0])->toBeInstanceOf(IndustryFacility::class)
+        ->and($result->data[0]->facility_id)->toBe(90000001)
+        ->and($result->data[0]->owner_id)->toBe(90000002)
+        ->and($result->data[0]->region_id)->toBe(90000003)
+        ->and($result->data[0]->solar_system_id)->toBe(90000004)
+        ->and($result->data[0]->tax)->toBe(1.5)
+        ->and($result->data[0]->type_id)->toBe(90000005)
+        ->and($result->data[1]->tax)->toBeNull();
+});
+
+it('fetches and maps industry systems with their cost indices', function (): void {
+    Http::fake([
+        'esi.evetech.net/industry/systems*' => Http::response([
+            [
+                'solar_system_id' => 90000001,
+                'cost_indices' => [
+                    ['activity' => 'copying', 'cost_index' => 1.5],
+                    ['activity' => 'manufacturing', 'cost_index' => 2.5],
+                ],
+            ],
+            [
+                'solar_system_id' => 90000002,
+                'cost_indices' => [],
+            ],
+        ]),
+    ]);
+
+    $result = (new Esi)->getIndustrySystems();
+
+    expect($result->wasSuccessful())->toBeTrue()
+        ->and($result->data)->toHaveCount(2)
+        ->and($result->data[0])->toBeInstanceOf(IndustrySystem::class)
+        ->and($result->data[0]->solar_system_id)->toBe(90000001)
+        ->and($result->data[0]->cost_indices)->toHaveCount(2)
+        ->and($result->data[0]->cost_indices[0]->activity)->toBe('copying')
+        ->and($result->data[0]->cost_indices[0]->cost_index)->toBe(1.5)
+        ->and($result->data[0]->cost_indices[1]->activity)->toBe('manufacturing')
+        ->and($result->data[0]->cost_indices[1]->cost_index)->toBe(2.5)
+        ->and($result->data[1]->cost_indices)->toBe([]);
+});
+
+it('fetches and maps character industry jobs', function (): void {
+    Http::fake([
+        'esi.evetech.net/characters/123/industry/jobs*' => Http::response([
+            [
+                'job_id' => 1,
+                'installer_id' => 2,
+                'facility_id' => 3,
+                'activity_id' => 4,
+                'blueprint_id' => 5,
+                'blueprint_type_id' => 6,
+                'blueprint_location_id' => 7,
+                'output_location_id' => 8,
+                'runs' => 9,
+                'status' => 'active',
+                'duration' => 10,
+                'start_date' => '2026-06-09T12:00:00Z',
+                'end_date' => '2026-06-10T12:00:00Z',
+                'station_id' => 11,
+                'cost' => 1.5,
+                'licensed_runs' => 12,
+                'probability' => 0.5,
+                'product_type_id' => 13,
+                'completed_character_id' => 14,
+                'completed_date' => '2026-06-11T12:00:00Z',
+                'pause_date' => '2026-06-12T12:00:00Z',
+                'successful_runs' => 15,
+            ],
+            [
+                'job_id' => 21,
+                'installer_id' => 22,
+                'facility_id' => 23,
+                'activity_id' => 24,
+                'blueprint_id' => 25,
+                'blueprint_type_id' => 26,
+                'blueprint_location_id' => 27,
+                'output_location_id' => 28,
+                'runs' => 29,
+                'status' => 'active',
+                'duration' => 30,
+                'start_date' => '2026-06-09T12:00:00Z',
+                'end_date' => '2026-06-10T12:00:00Z',
+                'station_id' => 31,
+            ],
+        ]),
+    ]);
+
+    $result = (new Esi)->getCharacterIndustryJobs(fakeCharacter());
+
+    expect($result->wasSuccessful())->toBeTrue()
+        ->and($result->data)->toHaveCount(2)
+        ->and($result->data[0])->toBeInstanceOf(IndustryJob::class)
+        ->and($result->data[0]->job_id)->toBe(1)
+        ->and($result->data[0]->installer_id)->toBe(2)
+        ->and($result->data[0]->facility_id)->toBe(3)
+        ->and($result->data[0]->activity_id)->toBe(4)
+        ->and($result->data[0]->blueprint_id)->toBe(5)
+        ->and($result->data[0]->blueprint_type_id)->toBe(6)
+        ->and($result->data[0]->blueprint_location_id)->toBe(7)
+        ->and($result->data[0]->output_location_id)->toBe(8)
+        ->and($result->data[0]->runs)->toBe(9)
+        ->and($result->data[0]->status)->toBe('active')
+        ->and($result->data[0]->duration)->toBe(10)
+        ->and($result->data[0]->start_date)->toBe('2026-06-09T12:00:00Z')
+        ->and($result->data[0]->end_date)->toBe('2026-06-10T12:00:00Z')
+        ->and($result->data[0]->station_id)->toBe(11)
+        ->and($result->data[0]->location_id)->toBeNull()
+        ->and($result->data[0]->cost)->toBe(1.5)
+        ->and($result->data[0]->licensed_runs)->toBe(12)
+        ->and($result->data[0]->probability)->toBe(0.5)
+        ->and($result->data[0]->product_type_id)->toBe(13)
+        ->and($result->data[0]->completed_character_id)->toBe(14)
+        ->and($result->data[0]->completed_date)->toBe('2026-06-11T12:00:00Z')
+        ->and($result->data[0]->pause_date)->toBe('2026-06-12T12:00:00Z')
+        ->and($result->data[0]->successful_runs)->toBe(15)
+        ->and($result->data[1]->cost)->toBeNull()
+        ->and($result->data[1]->licensed_runs)->toBeNull()
+        ->and($result->data[1]->probability)->toBeNull()
+        ->and($result->data[1]->product_type_id)->toBeNull()
+        ->and($result->data[1]->completed_character_id)->toBeNull()
+        ->and($result->data[1]->completed_date)->toBeNull()
+        ->and($result->data[1]->pause_date)->toBeNull()
+        ->and($result->data[1]->successful_runs)->toBeNull();
+});
+
+it('fetches and maps paginated corporation industry jobs', function (): void {
+    Http::fake([
+        'esi.evetech.net/corporations/456/industry/jobs*' => Http::response([
+            [
+                'job_id' => 1,
+                'installer_id' => 2,
+                'facility_id' => 3,
+                'activity_id' => 4,
+                'blueprint_id' => 5,
+                'blueprint_type_id' => 6,
+                'blueprint_location_id' => 7,
+                'output_location_id' => 8,
+                'runs' => 9,
+                'status' => 'active',
+                'duration' => 10,
+                'start_date' => '2026-06-09T12:00:00Z',
+                'end_date' => '2026-06-10T12:00:00Z',
+                'location_id' => 11,
+            ],
+        ], 200, ['X-Pages' => '1']),
+    ]);
+
+    $result = (new Esi)->getCorporationIndustryJobs(fakeCharacter(), 456);
+
+    expect($result->wasSuccessful())->toBeTrue()
+        ->and($result->data)->toHaveCount(1)
+        ->and($result->data[0])->toBeInstanceOf(IndustryJob::class)
+        ->and($result->data[0]->job_id)->toBe(1)
+        ->and($result->data[0]->location_id)->toBe(11)
+        ->and($result->data[0]->station_id)->toBeNull();
+});
+
+it('fetches and maps paginated character mining ledger entries', function (): void {
+    Http::fake([
+        'esi.evetech.net/characters/123/mining*' => Http::response([
+            [
+                'date' => '2026-06-09',
+                'quantity' => 100,
+                'solar_system_id' => 90000001,
+                'type_id' => 90000002,
+            ],
+        ], 200, ['X-Pages' => '1']),
+    ]);
+
+    $result = (new Esi)->getCharacterMining(fakeCharacter());
+
+    expect($result->wasSuccessful())->toBeTrue()
+        ->and($result->data)->toHaveCount(1)
+        ->and($result->data[0])->toBeInstanceOf(MiningLedgerEntry::class)
+        ->and($result->data[0]->date)->toBe('2026-06-09')
+        ->and($result->data[0]->quantity)->toBe(100)
+        ->and($result->data[0]->solar_system_id)->toBe(90000001)
+        ->and($result->data[0]->type_id)->toBe(90000002);
+});
+
+it('fetches and maps paginated corporation mining extractions using the singular corporation path', function (): void {
+    Http::fake([
+        'esi.evetech.net/corporation/456/mining/extractions*' => Http::response([
+            [
+                'structure_id' => 90000001,
+                'moon_id' => 90000002,
+                'extraction_start_time' => '2026-06-09T12:00:00Z',
+                'chunk_arrival_time' => '2026-06-10T12:00:00Z',
+                'natural_decay_time' => '2026-06-11T12:00:00Z',
+            ],
+        ], 200, ['X-Pages' => '1']),
+    ]);
+
+    $result = (new Esi)->getCorporationMiningExtractions(fakeCharacter(), 456);
+
+    expect($result->wasSuccessful())->toBeTrue()
+        ->and($result->data)->toHaveCount(1)
+        ->and($result->data[0])->toBeInstanceOf(MiningExtraction::class)
+        ->and($result->data[0]->structure_id)->toBe(90000001)
+        ->and($result->data[0]->moon_id)->toBe(90000002)
+        ->and($result->data[0]->extraction_start_time)->toBe('2026-06-09T12:00:00Z')
+        ->and($result->data[0]->chunk_arrival_time)->toBe('2026-06-10T12:00:00Z')
+        ->and($result->data[0]->natural_decay_time)->toBe('2026-06-11T12:00:00Z');
+
+    Http::assertSent(fn ($request) => str_contains($request->url(), '/corporation/456/mining/extractions'));
+});
+
+it('fetches and maps paginated corporation mining observers', function (): void {
+    Http::fake([
+        'esi.evetech.net/corporation/456/mining/observers*' => Http::response([
+            [
+                'last_updated' => '2026-06-09',
+                'observer_id' => 90000001,
+                'observer_type' => 'structure',
+            ],
+        ], 200, ['X-Pages' => '1']),
+    ]);
+
+    $result = (new Esi)->getCorporationMiningObservers(fakeCharacter(), 456);
+
+    expect($result->wasSuccessful())->toBeTrue()
+        ->and($result->data)->toHaveCount(1)
+        ->and($result->data[0])->toBeInstanceOf(MiningObserver::class)
+        ->and($result->data[0]->last_updated)->toBe('2026-06-09')
+        ->and($result->data[0]->observer_id)->toBe(90000001)
+        ->and($result->data[0]->observer_type)->toBe('structure');
+});
+
+it('fetches and maps paginated corporation mining observer entries', function (): void {
+    Http::fake([
+        'esi.evetech.net/corporation/456/mining/observers/90000001*' => Http::response([
+            [
+                'last_updated' => '2026-06-09',
+                'character_id' => 90000002,
+                'recorded_corporation_id' => 456,
+                'type_id' => 90000003,
+                'quantity' => 100,
+            ],
+        ], 200, ['X-Pages' => '1']),
+    ]);
+
+    $result = (new Esi)->getCorporationMiningObserver(fakeCharacter(), 456, 90000001);
+
+    expect($result->wasSuccessful())->toBeTrue()
+        ->and($result->data)->toHaveCount(1)
+        ->and($result->data[0])->toBeInstanceOf(MiningObserverEntry::class)
+        ->and($result->data[0]->last_updated)->toBe('2026-06-09')
+        ->and($result->data[0]->character_id)->toBe(90000002)
+        ->and($result->data[0]->recorded_corporation_id)->toBe(456)
+        ->and($result->data[0]->type_id)->toBe(90000003)
+        ->and($result->data[0]->quantity)->toBe(100);
+});
+
+it('returns an error result when an industry endpoint fails with a server error', function (): void {
+    Http::fake([
+        'esi.evetech.net/industry/facilities*' => Http::response(['error' => 'Internal server error'], 500),
+    ]);
+
+    $result = (new Esi)->getIndustryFacilities();
+
+    expect($result->failed())->toBeTrue()
+        ->and($result->error?->code)->toBe(500);
+});


### PR DESCRIPTION
Industry domain (8 endpoints): facilities/systems (public), character/corporation jobs, and mining (ledger/extractions/observers). 8 DTOs, 4 scopes. PHPStan level 9 clean, 100% coverage (258 tests).