### PR TITLE
feat: add structure and corporation project endpoints

### DIFF
--- a/src/DTO/CorporationProject.php
+++ b/src/DTO/CorporationProject.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\DTO;
+
+use NicolasKion\Esi\Support\Data;
+
+/**
+ * A corporation project.
+ *
+ * This is a superset of the two shapes ESI returns: the listing endpoint
+ * only reports `id`, `name`, `state`, `last_modified`, and `progress`, while
+ * the detail endpoint adds `creator`, `details`, `configuration`, and
+ * `contribution`. Fields only present in the detail response are nullable.
+ *
+ * `configuration` describes a project-type-specific goal (e.g. capturing a
+ * faction warfare complex, destroying a ship, delivering an item) as one of
+ * 17 differently-shaped variants keyed by type name. It is left as a raw
+ * decoded array rather than modeled as individual DTOs for each variant.
+ */
+readonly class CorporationProject extends Dto
+{
+    /**
+     * @param  array<string, mixed>|null  $configuration
+     */
+    public function __construct(
+        public string $id,
+        public string $name,
+        public string $state,
+        public string $last_modified,
+        public CorporationProjectProgress $progress,
+        public ?CorporationProjectReward $reward,
+        public ?CorporationProjectCreator $creator,
+        public ?CorporationProjectDetails $details,
+        public ?array $configuration,
+        public ?CorporationProjectContributionSettings $contribution,
+    ) {}
+
+    public static function fromData(Data $data): self
+    {
+        /** @var array<string, mixed>|null $configuration */
+        $configuration = $data->raw('configuration');
+
+        return new self(
+            id: $data->string('id', ''),
+            name: $data->string('name', ''),
+            state: $data->string('state', ''),
+            last_modified: $data->string('last_modified', ''),
+            progress: CorporationProjectProgress::fromData($data->object('progress')),
+            reward: $data->has('reward') ? CorporationProjectReward::fromData($data->object('reward')) : null,
+            creator: $data->has('creator') ? CorporationProjectCreator::fromData($data->object('creator')) : null,
+            details: $data->has('details') ? CorporationProjectDetails::fromData($data->object('details')) : null,
+            configuration: is_array($configuration) ? $configuration : null,
+            contribution: $data->has('contribution') ? CorporationProjectContributionSettings::fromData($data->object('contribution')) : null,
+        );
+    }
+}

--- a/src/DTO/CorporationProjectContributionSettings.php
+++ b/src/DTO/CorporationProjectContributionSettings.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\DTO;
+
+use NicolasKion\Esi\Support\Data;
+
+/**
+ * The contribution rules configured for a project (limits, ISK reward per
+ * contribution, and progress multiplier). Not to be confused with
+ * {@see ProjectContribution}, which reports a single character's actual
+ * contribution to a project.
+ */
+readonly class CorporationProjectContributionSettings extends Dto
+{
+    public function __construct(
+        public ?int $participation_limit,
+        public ?float $reward_per_contribution,
+        public ?int $submission_limit,
+        public ?float $submission_multiplier,
+    ) {}
+
+    public static function fromData(Data $data): self
+    {
+        return new self(
+            participation_limit: $data->integer('participation_limit'),
+            reward_per_contribution: $data->float('reward_per_contribution'),
+            submission_limit: $data->integer('submission_limit'),
+            submission_multiplier: $data->float('submission_multiplier'),
+        );
+    }
+}

--- a/src/DTO/CorporationProjectCreator.php
+++ b/src/DTO/CorporationProjectCreator.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\DTO;
+
+use NicolasKion\Esi\Support\Data;
+
+readonly class CorporationProjectCreator extends Dto
+{
+    public function __construct(
+        public int $id,
+        public string $name,
+    ) {}
+
+    public static function fromData(Data $data): self
+    {
+        return new self(
+            id: $data->integer('id', 0),
+            name: $data->string('name', ''),
+        );
+    }
+}

--- a/src/DTO/CorporationProjectDetails.php
+++ b/src/DTO/CorporationProjectDetails.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\DTO;
+
+use NicolasKion\Esi\Support\Data;
+
+readonly class CorporationProjectDetails extends Dto
+{
+    public function __construct(
+        public string $career,
+        public string $created,
+        public string $description,
+        public ?string $expires,
+        public ?string $finished,
+    ) {}
+
+    public static function fromData(Data $data): self
+    {
+        return new self(
+            career: $data->string('career', ''),
+            created: $data->string('created', ''),
+            description: $data->string('description', ''),
+            expires: $data->string('expires'),
+            finished: $data->string('finished'),
+        );
+    }
+}

--- a/src/DTO/CorporationProjectProgress.php
+++ b/src/DTO/CorporationProjectProgress.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\DTO;
+
+use NicolasKion\Esi\Support\Data;
+
+readonly class CorporationProjectProgress extends Dto
+{
+    public function __construct(
+        public int $current,
+        public int $desired,
+    ) {}
+
+    public static function fromData(Data $data): self
+    {
+        return new self(
+            current: $data->integer('current', 0),
+            desired: $data->integer('desired', 0),
+        );
+    }
+}

--- a/src/DTO/CorporationProjectReward.php
+++ b/src/DTO/CorporationProjectReward.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\DTO;
+
+use NicolasKion\Esi\Support\Data;
+
+readonly class CorporationProjectReward extends Dto
+{
+    public function __construct(
+        public float $initial,
+        public float $remaining,
+    ) {}
+
+    public static function fromData(Data $data): self
+    {
+        return new self(
+            initial: $data->float('initial', 0.0),
+            remaining: $data->float('remaining', 0.0),
+        );
+    }
+}

--- a/src/DTO/MercenaryDen.php
+++ b/src/DTO/MercenaryDen.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\DTO;
+
+use NicolasKion\Esi\Support\Data;
+
+/**
+ * A character's Mercenary Den.
+ *
+ * This is a superset of the two shapes ESI returns: the listing endpoint
+ * only reports `id` and `planet_id`, while the detail endpoint omits
+ * `planet_id` at the top level (it is nested under `skyhook` instead) and
+ * adds the remaining fields. Fields that are only present in one of the two
+ * shapes are nullable here.
+ */
+readonly class MercenaryDen extends Dto
+{
+    public function __construct(
+        public int $id,
+        public ?int $planet_id,
+        public ?string $state,
+        public ?int $type_id,
+        public ?MercenaryDenSkyhook $skyhook,
+        public ?MercenaryDenInfomorphs $infomorphs,
+        public ?MercenaryDenEvolution $evolution,
+        public ?string $reinforcement_timer_end,
+    ) {}
+
+    public static function fromData(Data $data): self
+    {
+        return new self(
+            id: $data->integer('id', 0),
+            planet_id: $data->integer('planet_id'),
+            state: $data->string('state'),
+            type_id: $data->integer('type_id'),
+            skyhook: $data->has('skyhook') ? MercenaryDenSkyhook::fromData($data->object('skyhook')) : null,
+            infomorphs: $data->has('infomorphs') ? MercenaryDenInfomorphs::fromData($data->object('infomorphs')) : null,
+            evolution: $data->has('evolution') ? MercenaryDenEvolution::fromData($data->object('evolution')) : null,
+            reinforcement_timer_end: $data->has('reinforcement_timer') ? $data->object('reinforcement_timer')->string('end') : null,
+        );
+    }
+}

--- a/src/DTO/MercenaryDenEvolution.php
+++ b/src/DTO/MercenaryDenEvolution.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\DTO;
+
+use NicolasKion\Esi\Support\Data;
+
+readonly class MercenaryDenEvolution extends Dto
+{
+    public function __construct(
+        public MercenaryDenEvolutionLevel $anarchy,
+        public MercenaryDenEvolutionLevel $development,
+    ) {}
+
+    public static function fromData(Data $data): self
+    {
+        return new self(
+            anarchy: MercenaryDenEvolutionLevel::fromData($data->object('anarchy')),
+            development: MercenaryDenEvolutionLevel::fromData($data->object('development')),
+        );
+    }
+}

--- a/src/DTO/MercenaryDenEvolutionLevel.php
+++ b/src/DTO/MercenaryDenEvolutionLevel.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\DTO;
+
+use NicolasKion\Esi\Support\Data;
+
+/**
+ * A cumulative amount/level pair used by both the "anarchy" and
+ * "development" facets of a Mercenary Den's evolution.
+ */
+readonly class MercenaryDenEvolutionLevel extends Dto
+{
+    public function __construct(
+        public int $amount,
+        public string $level,
+    ) {}
+
+    public static function fromData(Data $data): self
+    {
+        return new self(
+            amount: $data->integer('amount', 0),
+            level: $data->string('level', ''),
+        );
+    }
+}

--- a/src/DTO/MercenaryDenInfomorphs.php
+++ b/src/DTO/MercenaryDenInfomorphs.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\DTO;
+
+use NicolasKion\Esi\Support\Data;
+
+readonly class MercenaryDenInfomorphs extends Dto
+{
+    public function __construct(
+        public int $amount,
+    ) {}
+
+    public static function fromData(Data $data): self
+    {
+        return new self(
+            amount: $data->integer('amount', 0),
+        );
+    }
+}

--- a/src/DTO/MercenaryDenSkyhook.php
+++ b/src/DTO/MercenaryDenSkyhook.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\DTO;
+
+use NicolasKion\Esi\Support\Data;
+
+/**
+ * The Skyhook a Mercenary Den is attached to, as embedded in the den's
+ * detail response.
+ */
+readonly class MercenaryDenSkyhook extends Dto
+{
+    public function __construct(
+        public int $id,
+        public int $planet_id,
+        public int $corporation_id,
+    ) {}
+
+    public static function fromData(Data $data): self
+    {
+        return new self(
+            id: $data->integer('id', 0),
+            planet_id: $data->integer('planet_id', 0),
+            corporation_id: $data->integer('corporation_id', 0),
+        );
+    }
+}

--- a/src/DTO/ProjectContribution.php
+++ b/src/DTO/ProjectContribution.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\DTO;
+
+use NicolasKion\Esi\Support\Data;
+
+/**
+ * A single character's contribution to a corporation project.
+ */
+readonly class ProjectContribution extends Dto
+{
+    public function __construct(
+        public int $contributed,
+        public ?string $last_modified,
+    ) {}
+
+    public static function fromData(Data $data): self
+    {
+        return new self(
+            contributed: $data->integer('contributed', 0),
+            last_modified: $data->string('last_modified'),
+        );
+    }
+}

--- a/src/DTO/ProjectContributor.php
+++ b/src/DTO/ProjectContributor.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\DTO;
+
+use NicolasKion\Esi\Support\Data;
+
+/**
+ * A character who has contributed to a corporation project.
+ */
+readonly class ProjectContributor extends Dto
+{
+    public function __construct(
+        public int $id,
+        public string $name,
+        public int $contributed,
+    ) {}
+
+    public static function fromData(Data $data): self
+    {
+        return new self(
+            id: $data->integer('id', 0),
+            name: $data->string('name', ''),
+            contributed: $data->integer('contributed', 0),
+        );
+    }
+}

--- a/src/DTO/Skyhook.php
+++ b/src/DTO/Skyhook.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\DTO;
+
+use NicolasKion\Esi\Support\Data;
+
+/**
+ * A corporation's Skyhook.
+ *
+ * This is a superset of the two shapes ESI returns: the listing endpoint
+ * only reports `id` and `planet_id`, while the detail endpoint adds the
+ * remaining fields. Fields only present in the detail response are nullable.
+ */
+readonly class Skyhook extends Dto
+{
+    /**
+     * @param  array<int, SkyhookReagent>  $reagents
+     */
+    public function __construct(
+        public int $id,
+        public int $planet_id,
+        public ?int $effective_workforce,
+        public ?bool $is_active,
+        public ?string $state,
+        public array $reagents,
+        public ?string $reinforcement_timer_end,
+        public ?SkyhookTheftVulnerability $theft_vulnerability,
+    ) {}
+
+    public static function fromData(Data $data): self
+    {
+        return new self(
+            id: $data->integer('id', 0),
+            planet_id: $data->integer('planet_id', 0),
+            effective_workforce: $data->integer('effective_workforce'),
+            is_active: $data->boolean('is_active'),
+            state: $data->string('state'),
+            reagents: $data->list('reagents', SkyhookReagent::fromData(...)),
+            reinforcement_timer_end: $data->has('reinforcement_timer') ? $data->object('reinforcement_timer')->string('end') : null,
+            theft_vulnerability: $data->has('theft_vulnerability') ? SkyhookTheftVulnerability::fromData($data->object('theft_vulnerability')) : null,
+        );
+    }
+}

--- a/src/DTO/SkyhookReagent.php
+++ b/src/DTO/SkyhookReagent.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\DTO;
+
+use NicolasKion\Esi\Support\Data;
+
+readonly class SkyhookReagent extends Dto
+{
+    public function __construct(
+        public int $type_id,
+        public int $secured_stock,
+        public int $unsecured_stock,
+        public string $last_cycle,
+    ) {}
+
+    public static function fromData(Data $data): self
+    {
+        return new self(
+            type_id: $data->integer('type_id', 0),
+            secured_stock: $data->integer('secured_stock', 0),
+            unsecured_stock: $data->integer('unsecured_stock', 0),
+            last_cycle: $data->string('last_cycle', ''),
+        );
+    }
+}

--- a/src/DTO/SovereigntyHub.php
+++ b/src/DTO/SovereigntyHub.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\DTO;
+
+use NicolasKion\Esi\Support\Data;
+
+/**
+ * A corporation's Sovereignty Hub.
+ *
+ * This is a superset of the two shapes ESI returns: the listing endpoint
+ * only reports `id` and `solar_system_id`, while the detail endpoint adds
+ * the remaining fields. Fields only present in the detail response are
+ * nullable.
+ */
+readonly class SovereigntyHub extends Dto
+{
+    /**
+     * @param  array<int, SovereigntyHubUpgrade>  $upgrades
+     */
+    public function __construct(
+        public int $id,
+        public int $solar_system_id,
+        public ?int $fuel_access_list_id,
+        public ?SovereigntyHubReagentBay $reagent_bay,
+        public ?SovereigntyHubResources $resources,
+        public array $upgrades,
+        public ?SovereigntyHubVulnerabilityWindow $vulnerability_window,
+        public ?SovereigntyHubWorkforceTransport $workforce_transport,
+    ) {}
+
+    public static function fromData(Data $data): self
+    {
+        return new self(
+            id: $data->integer('id', 0),
+            solar_system_id: $data->integer('solar_system_id', 0),
+            fuel_access_list_id: $data->integer('fuel_access_list_id'),
+            reagent_bay: $data->has('reagent_bay') ? SovereigntyHubReagentBay::fromData($data->object('reagent_bay')) : null,
+            resources: $data->has('resources') ? SovereigntyHubResources::fromData($data->object('resources')) : null,
+            upgrades: $data->list('upgrades', SovereigntyHubUpgrade::fromData(...)),
+            vulnerability_window: $data->has('vulnerability_window') ? SovereigntyHubVulnerabilityWindow::fromData($data->object('vulnerability_window')) : null,
+            workforce_transport: $data->has('workforce_transport') ? SovereigntyHubWorkforceTransport::fromData($data->object('workforce_transport')) : null,
+        );
+    }
+}

--- a/src/DTO/SovereigntyHubReagent.php
+++ b/src/DTO/SovereigntyHubReagent.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\DTO;
+
+use NicolasKion\Esi\Support\Data;
+
+readonly class SovereigntyHubReagent extends Dto
+{
+    public function __construct(
+        public int $type_id,
+        public int $amount,
+        public int $burning_per_hour,
+    ) {}
+
+    public static function fromData(Data $data): self
+    {
+        return new self(
+            type_id: $data->integer('type_id', 0),
+            amount: $data->integer('amount', 0),
+            burning_per_hour: $data->integer('burning_per_hour', 0),
+        );
+    }
+}

--- a/src/DTO/SovereigntyHubReagentBay.php
+++ b/src/DTO/SovereigntyHubReagentBay.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\DTO;
+
+use NicolasKion\Esi\Support\Data;
+
+readonly class SovereigntyHubReagentBay extends Dto
+{
+    /**
+     * @param  array<int, SovereigntyHubReagent>  $reagents
+     */
+    public function __construct(
+        public string $last_updated,
+        public array $reagents,
+    ) {}
+
+    public static function fromData(Data $data): self
+    {
+        return new self(
+            last_updated: $data->string('last_updated', ''),
+            reagents: $data->list('reagents', SovereigntyHubReagent::fromData(...)),
+        );
+    }
+}

--- a/src/DTO/SovereigntyHubResourceValue.php
+++ b/src/DTO/SovereigntyHubResourceValue.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\DTO;
+
+use NicolasKion\Esi\Support\Data;
+
+/**
+ * An allocated/available pair, used for both the power and workforce
+ * resources of a Sovereignty Hub.
+ */
+readonly class SovereigntyHubResourceValue extends Dto
+{
+    public function __construct(
+        public int $allocated,
+        public int $available,
+    ) {}
+
+    public static function fromData(Data $data): self
+    {
+        return new self(
+            allocated: $data->integer('allocated', 0),
+            available: $data->integer('available', 0),
+        );
+    }
+}

--- a/src/DTO/SovereigntyHubResources.php
+++ b/src/DTO/SovereigntyHubResources.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\DTO;
+
+use NicolasKion\Esi\Support\Data;
+
+readonly class SovereigntyHubResources extends Dto
+{
+    public function __construct(
+        public SovereigntyHubResourceValue $power,
+        public SovereigntyHubResourceValue $workforce,
+    ) {}
+
+    public static function fromData(Data $data): self
+    {
+        return new self(
+            power: SovereigntyHubResourceValue::fromData($data->object('power')),
+            workforce: SovereigntyHubResourceValue::fromData($data->object('workforce')),
+        );
+    }
+}

--- a/src/DTO/SovereigntyHubTransportExport.php
+++ b/src/DTO/SovereigntyHubTransportExport.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\DTO;
+
+use NicolasKion\Esi\Support\Data;
+
+readonly class SovereigntyHubTransportExport extends Dto
+{
+    public function __construct(
+        public ?int $amount,
+        public ?int $solar_system_id,
+    ) {}
+
+    public static function fromData(Data $data): self
+    {
+        return new self(
+            amount: $data->integer('amount'),
+            solar_system_id: $data->integer('solar_system_id'),
+        );
+    }
+}

--- a/src/DTO/SovereigntyHubTransportImport.php
+++ b/src/DTO/SovereigntyHubTransportImport.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\DTO;
+
+use NicolasKion\Esi\Support\Data;
+
+readonly class SovereigntyHubTransportImport extends Dto
+{
+    /**
+     * @param  array<int, SovereigntyHubTransportSource>  $sources
+     */
+    public function __construct(
+        public array $sources,
+    ) {}
+
+    public static function fromData(Data $data): self
+    {
+        return new self(
+            sources: $data->list('sources', SovereigntyHubTransportSource::fromData(...)),
+        );
+    }
+}

--- a/src/DTO/SovereigntyHubTransportSection.php
+++ b/src/DTO/SovereigntyHubTransportSection.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\DTO;
+
+use NicolasKion\Esi\Support\Data;
+
+/**
+ * A workforce-transport section: ESI models `configuration` (what was
+ * requested) and `state` (what is currently happening) as a discriminated
+ * union of `import`, `export`, or `transit`. Only one of the three is
+ * populated in any given response, so all three are nullable here.
+ */
+readonly class SovereigntyHubTransportSection extends Dto
+{
+    public function __construct(
+        public ?SovereigntyHubTransportImport $import,
+        public ?SovereigntyHubTransportExport $export,
+        public ?bool $transit,
+    ) {}
+
+    public static function fromData(Data $data): self
+    {
+        return new self(
+            import: $data->has('import') ? SovereigntyHubTransportImport::fromData($data->object('import')) : null,
+            export: $data->has('export') ? SovereigntyHubTransportExport::fromData($data->object('export')) : null,
+            transit: $data->boolean('transit'),
+        );
+    }
+}

--- a/src/DTO/SovereigntyHubTransportSource.php
+++ b/src/DTO/SovereigntyHubTransportSource.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\DTO;
+
+use NicolasKion\Esi\Support\Data;
+
+/**
+ * A source solar system for a workforce transport import, used for both the
+ * configured (no `amount`) and current-state (with `amount`) shapes; `amount`
+ * is nullable to accommodate both.
+ */
+readonly class SovereigntyHubTransportSource extends Dto
+{
+    public function __construct(
+        public int $solar_system_id,
+        public ?int $amount,
+    ) {}
+
+    public static function fromData(Data $data): self
+    {
+        return new self(
+            solar_system_id: $data->integer('solar_system_id', 0),
+            amount: $data->integer('amount'),
+        );
+    }
+}

--- a/src/DTO/SovereigntyHubUpgrade.php
+++ b/src/DTO/SovereigntyHubUpgrade.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\DTO;
+
+use NicolasKion\Esi\Support\Data;
+
+readonly class SovereigntyHubUpgrade extends Dto
+{
+    public function __construct(
+        public int $type_id,
+        public string $power_state,
+    ) {}
+
+    public static function fromData(Data $data): self
+    {
+        return new self(
+            type_id: $data->integer('type_id', 0),
+            power_state: $data->string('power_state', ''),
+        );
+    }
+}

--- a/src/DTO/SovereigntyHubVulnerabilityWindow.php
+++ b/src/DTO/SovereigntyHubVulnerabilityWindow.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\DTO;
+
+use NicolasKion\Esi\Support\Data;
+
+readonly class SovereigntyHubVulnerabilityWindow extends Dto
+{
+    public function __construct(
+        public string $start,
+        public string $end,
+    ) {}
+
+    public static function fromData(Data $data): self
+    {
+        return new self(
+            start: $data->string('start', ''),
+            end: $data->string('end', ''),
+        );
+    }
+}

--- a/src/DTO/SovereigntyHubWorkforceTransport.php
+++ b/src/DTO/SovereigntyHubWorkforceTransport.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\DTO;
+
+use NicolasKion\Esi\Support\Data;
+
+readonly class SovereigntyHubWorkforceTransport extends Dto
+{
+    public function __construct(
+        public ?SovereigntyHubTransportSection $configuration,
+        public ?SovereigntyHubTransportSection $state,
+    ) {}
+
+    public static function fromData(Data $data): self
+    {
+        return new self(
+            configuration: $data->has('configuration') ? SovereigntyHubTransportSection::fromData($data->object('configuration')) : null,
+            state: $data->has('state') ? SovereigntyHubTransportSection::fromData($data->object('state')) : null,
+        );
+    }
+}

--- a/src/Enums/EsiScope.php
+++ b/src/Enums/EsiScope.php
@@ -69,6 +69,9 @@ enum EsiScope: string
     case WriteFittings = 'esi-fittings.write_fittings.v1';
     case ManagePlanets = 'esi-planets.manage_planets.v1';
     case ReadCustomsOffices = 'esi-planets.read_customs_offices.v1';
+    case ReadCharacterStructures = 'esi-structures.read_character.v1';
+    case ReadCorporationStructureList = 'esi-structures.read_corporation.v1';
+    case ReadCorporationProjects = 'esi-corporations.read_projects.v1';
 
     /**
      * @return array<int, string>

--- a/src/Esi.php
+++ b/src/Esi.php
@@ -42,6 +42,7 @@ use NicolasKion\Esi\DTO\CorporationFactionWarfareStats;
 use NicolasKion\Esi\DTO\CorporationHistory;
 use NicolasKion\Esi\DTO\CorporationIcons;
 use NicolasKion\Esi\DTO\CorporationMedal;
+use NicolasKion\Esi\DTO\CorporationProject;
 use NicolasKion\Esi\DTO\CorporationRoles;
 use NicolasKion\Esi\DTO\CorporationStructure;
 use NicolasKion\Esi\DTO\CorporationTitle;
@@ -86,6 +87,7 @@ use NicolasKion\Esi\DTO\MarketOrder;
 use NicolasKion\Esi\DTO\MarketPrice;
 use NicolasKion\Esi\DTO\MemberTitles;
 use NicolasKion\Esi\DTO\MemberTracking;
+use NicolasKion\Esi\DTO\MercenaryDen;
 use NicolasKion\Esi\DTO\MiningExtraction;
 use NicolasKion\Esi\DTO\MiningLedgerEntry;
 use NicolasKion\Esi\DTO\MiningObserver;
@@ -99,6 +101,8 @@ use NicolasKion\Esi\DTO\PersonalMarketOrderHistory;
 use NicolasKion\Esi\DTO\Planet;
 use NicolasKion\Esi\DTO\PlanetColony;
 use NicolasKion\Esi\DTO\PlanetLayout;
+use NicolasKion\Esi\DTO\ProjectContribution;
+use NicolasKion\Esi\DTO\ProjectContributor;
 use NicolasKion\Esi\DTO\PublicContract;
 use NicolasKion\Esi\DTO\PublicContractBid;
 use NicolasKion\Esi\DTO\PublicContractItem;
@@ -110,7 +114,9 @@ use NicolasKion\Esi\DTO\Schematic;
 use NicolasKion\Esi\DTO\Shareholder;
 use NicolasKion\Esi\DTO\Ship;
 use NicolasKion\Esi\DTO\SkillQueueEntry;
+use NicolasKion\Esi\DTO\Skyhook;
 use NicolasKion\Esi\DTO\Sovereignty;
+use NicolasKion\Esi\DTO\SovereigntyHub;
 use NicolasKion\Esi\DTO\Standing;
 use NicolasKion\Esi\DTO\Star;
 use NicolasKion\Esi\DTO\Starbase;
@@ -219,11 +225,19 @@ use NicolasKion\Esi\Requests\GetCorporationMiningObserverRequest;
 use NicolasKion\Esi\Requests\GetCorporationMiningObserversRequest;
 use NicolasKion\Esi\Requests\GetCorporationOrderHistoryRequest;
 use NicolasKion\Esi\Requests\GetCorporationOrdersRequest;
+use NicolasKion\Esi\Requests\GetCorporationProjectContributionRequest;
+use NicolasKion\Esi\Requests\GetCorporationProjectContributorsRequest;
+use NicolasKion\Esi\Requests\GetCorporationProjectRequest;
+use NicolasKion\Esi\Requests\GetCorporationProjectsRequest;
 use NicolasKion\Esi\Requests\GetCorporationRecentKillmailsRequest;
 use NicolasKion\Esi\Requests\GetCorporationRequest;
 use NicolasKion\Esi\Requests\GetCorporationRolesHistoryRequest;
 use NicolasKion\Esi\Requests\GetCorporationRolesRequest;
 use NicolasKion\Esi\Requests\GetCorporationShareholdersRequest;
+use NicolasKion\Esi\Requests\GetCorporationSkyhookRequest;
+use NicolasKion\Esi\Requests\GetCorporationSkyhooksRequest;
+use NicolasKion\Esi\Requests\GetCorporationSovereigntyHubRequest;
+use NicolasKion\Esi\Requests\GetCorporationSovereigntyHubsRequest;
 use NicolasKion\Esi\Requests\GetCorporationStandingsRequest;
 use NicolasKion\Esi\Requests\GetCorporationStarbaseRequest;
 use NicolasKion\Esi\Requests\GetCorporationStarbasesRequest;
@@ -269,6 +283,8 @@ use NicolasKion\Esi\Requests\GetMarketHistoryRequest;
 use NicolasKion\Esi\Requests\GetMarketOrdersRequest;
 use NicolasKion\Esi\Requests\GetMarketPricesRequest;
 use NicolasKion\Esi\Requests\GetMarketTypesRequest;
+use NicolasKion\Esi\Requests\GetMercenaryDenRequest;
+use NicolasKion\Esi\Requests\GetMercenaryDensRequest;
 use NicolasKion\Esi\Requests\GetMoonRequest;
 use NicolasKion\Esi\Requests\GetNamesRequest;
 use NicolasKion\Esi\Requests\GetNpcCorporationsRequest;
@@ -2912,6 +2928,136 @@ class Esi
     {
         $connector = $this->getAuthenticatedConnector($character, EsiScope::OpenWindow);
         $request = new OpenNewMailWindowRequest($recipients, $subject, $body, $to_corp_or_alliance_id);
+
+        return $connector->send($request);
+    }
+
+    /**
+     * Retrieves a character's Mercenary Dens.
+     *
+     * @return EsiResult<array<int, MercenaryDen>>
+     */
+    public function getMercenaryDens(Character $character): EsiResult
+    {
+        $connector = $this->getAuthenticatedConnector($character, EsiScope::ReadCharacterStructures);
+        $request = new GetMercenaryDensRequest($character->getId());
+
+        return $connector->send($request);
+    }
+
+    /**
+     * Retrieves detailed information about one of a character's Mercenary Dens.
+     *
+     * @return EsiResult<MercenaryDen>
+     */
+    public function getMercenaryDen(Character $character, int $mercenary_den_id): EsiResult
+    {
+        $connector = $this->getAuthenticatedConnector($character, EsiScope::ReadCharacterStructures);
+        $request = new GetMercenaryDenRequest($character->getId(), $mercenary_den_id);
+
+        return $connector->send($request);
+    }
+
+    /**
+     * Retrieves a corporation's Skyhooks.
+     *
+     * @return EsiResult<array<int, Skyhook>>
+     */
+    public function getCorporationSkyhooks(Character $character, int $corporation_id): EsiResult
+    {
+        $connector = $this->getAuthenticatedConnector($character, EsiScope::ReadCorporationStructureList);
+        $request = new GetCorporationSkyhooksRequest($corporation_id);
+
+        return $connector->send($request);
+    }
+
+    /**
+     * Retrieves detailed information about one of a corporation's Skyhooks.
+     *
+     * @return EsiResult<Skyhook>
+     */
+    public function getCorporationSkyhook(Character $character, int $corporation_id, int $skyhook_id): EsiResult
+    {
+        $connector = $this->getAuthenticatedConnector($character, EsiScope::ReadCorporationStructureList);
+        $request = new GetCorporationSkyhookRequest($corporation_id, $skyhook_id);
+
+        return $connector->send($request);
+    }
+
+    /**
+     * Retrieves a corporation's Sovereignty Hubs.
+     *
+     * @return EsiResult<array<int, SovereigntyHub>>
+     */
+    public function getCorporationSovereigntyHubs(Character $character, int $corporation_id): EsiResult
+    {
+        $connector = $this->getAuthenticatedConnector($character, EsiScope::ReadCorporationStructureList);
+        $request = new GetCorporationSovereigntyHubsRequest($corporation_id);
+
+        return $connector->send($request);
+    }
+
+    /**
+     * Retrieves detailed information about one of a corporation's Sovereignty Hubs.
+     *
+     * @return EsiResult<SovereigntyHub>
+     */
+    public function getCorporationSovereigntyHub(Character $character, int $corporation_id, int $sovereignty_hub_id): EsiResult
+    {
+        $connector = $this->getAuthenticatedConnector($character, EsiScope::ReadCorporationStructureList);
+        $request = new GetCorporationSovereigntyHubRequest($corporation_id, $sovereignty_hub_id);
+
+        return $connector->send($request);
+    }
+
+    /**
+     * Retrieves a corporation's projects.
+     *
+     * @return EsiResult<array<int, CorporationProject>>
+     */
+    public function getCorporationProjects(Character $character, int $corporation_id): EsiResult
+    {
+        $connector = $this->getAuthenticatedConnector($character, EsiScope::ReadCorporationProjects);
+        $request = new GetCorporationProjectsRequest($corporation_id);
+
+        return $connector->send($request);
+    }
+
+    /**
+     * Retrieves detailed information about one of a corporation's projects.
+     *
+     * @return EsiResult<CorporationProject>
+     */
+    public function getCorporationProject(Character $character, int $corporation_id, string $project_id): EsiResult
+    {
+        $connector = $this->getAuthenticatedConnector($character, EsiScope::ReadCorporationProjects);
+        $request = new GetCorporationProjectRequest($corporation_id, $project_id);
+
+        return $connector->send($request);
+    }
+
+    /**
+     * Retrieves a character's contribution to a corporation project.
+     *
+     * @return EsiResult<ProjectContribution>
+     */
+    public function getCorporationProjectContribution(Character $character, int $corporation_id, string $project_id, int $character_id): EsiResult
+    {
+        $connector = $this->getAuthenticatedConnector($character, EsiScope::ReadCorporationProjects);
+        $request = new GetCorporationProjectContributionRequest($corporation_id, $project_id, $character_id);
+
+        return $connector->send($request);
+    }
+
+    /**
+     * Retrieves the contributors to a corporation project.
+     *
+     * @return EsiResult<array<int, ProjectContributor>>
+     */
+    public function getCorporationProjectContributors(Character $character, int $corporation_id, string $project_id): EsiResult
+    {
+        $connector = $this->getAuthenticatedConnector($character, EsiScope::ReadCorporationProjects);
+        $request = new GetCorporationProjectContributorsRequest($corporation_id, $project_id);
 
         return $connector->send($request);
     }

--- a/src/Requests/GetCorporationProjectContributionRequest.php
+++ b/src/Requests/GetCorporationProjectContributionRequest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\Requests;
+
+use Illuminate\Http\Client\Response;
+use NicolasKion\Esi\DTO\ProjectContribution;
+use NicolasKion\Esi\Request;
+
+/**
+ * @extends Request<ProjectContribution>
+ */
+class GetCorporationProjectContributionRequest extends Request
+{
+    public function __construct(
+        public int $corporation_id,
+        public string $project_id,
+        public int $character_id,
+    ) {}
+
+    public function resolveEndpoint(): string
+    {
+        return sprintf('/corporations/%d/projects/%s/contribution/%d', $this->corporation_id, $this->project_id, $this->character_id);
+    }
+
+    public function createDto(Response $response, mixed $data): ProjectContribution
+    {
+        return ProjectContribution::hydrate($data);
+    }
+}

--- a/src/Requests/GetCorporationProjectContributorsRequest.php
+++ b/src/Requests/GetCorporationProjectContributorsRequest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\Requests;
+
+use Illuminate\Http\Client\Response;
+use NicolasKion\Esi\DTO\ProjectContributor;
+use NicolasKion\Esi\Request;
+use NicolasKion\Esi\Support\Data;
+
+/**
+ * @extends Request<array<int, ProjectContributor>>
+ */
+class GetCorporationProjectContributorsRequest extends Request
+{
+    public function __construct(
+        public int $corporation_id,
+        public string $project_id,
+    ) {}
+
+    public function resolveEndpoint(): string
+    {
+        return sprintf('/corporations/%d/projects/%s/contributors', $this->corporation_id, $this->project_id);
+    }
+
+    /**
+     * @return array<int, ProjectContributor>
+     */
+    public function createDto(Response $response, mixed $data): array
+    {
+        return ProjectContributor::hydrateList(Data::of($data)->raw('contributors'));
+    }
+}

--- a/src/Requests/GetCorporationProjectRequest.php
+++ b/src/Requests/GetCorporationProjectRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\Requests;
+
+use Illuminate\Http\Client\Response;
+use NicolasKion\Esi\DTO\CorporationProject;
+use NicolasKion\Esi\Request;
+
+/**
+ * @extends Request<CorporationProject>
+ */
+class GetCorporationProjectRequest extends Request
+{
+    public function __construct(
+        public int $corporation_id,
+        public string $project_id,
+    ) {}
+
+    public function resolveEndpoint(): string
+    {
+        return sprintf('/corporations/%d/projects/%s', $this->corporation_id, $this->project_id);
+    }
+
+    public function createDto(Response $response, mixed $data): CorporationProject
+    {
+        return CorporationProject::hydrate($data);
+    }
+}

--- a/src/Requests/GetCorporationProjectsRequest.php
+++ b/src/Requests/GetCorporationProjectsRequest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\Requests;
+
+use Illuminate\Http\Client\Response;
+use NicolasKion\Esi\DTO\CorporationProject;
+use NicolasKion\Esi\Request;
+use NicolasKion\Esi\Support\Data;
+
+/**
+ * @extends Request<array<int, CorporationProject>>
+ */
+class GetCorporationProjectsRequest extends Request
+{
+    public function __construct(public int $corporation_id) {}
+
+    public function resolveEndpoint(): string
+    {
+        return sprintf('/corporations/%d/projects', $this->corporation_id);
+    }
+
+    /**
+     * @return array<int, CorporationProject>
+     */
+    public function createDto(Response $response, mixed $data): array
+    {
+        return CorporationProject::hydrateList(Data::of($data)->raw('projects'));
+    }
+}

--- a/src/Requests/GetCorporationSkyhookRequest.php
+++ b/src/Requests/GetCorporationSkyhookRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\Requests;
+
+use Illuminate\Http\Client\Response;
+use NicolasKion\Esi\DTO\Skyhook;
+use NicolasKion\Esi\Request;
+
+/**
+ * @extends Request<Skyhook>
+ */
+class GetCorporationSkyhookRequest extends Request
+{
+    public function __construct(
+        public int $corporation_id,
+        public int $skyhook_id,
+    ) {}
+
+    public function resolveEndpoint(): string
+    {
+        return sprintf('/corporations/%d/structures/skyhooks/%d', $this->corporation_id, $this->skyhook_id);
+    }
+
+    public function createDto(Response $response, mixed $data): Skyhook
+    {
+        return Skyhook::hydrate($data);
+    }
+}

--- a/src/Requests/GetCorporationSkyhooksRequest.php
+++ b/src/Requests/GetCorporationSkyhooksRequest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\Requests;
+
+use Illuminate\Http\Client\Response;
+use NicolasKion\Esi\DTO\Skyhook;
+use NicolasKion\Esi\Request;
+use NicolasKion\Esi\Support\Data;
+
+/**
+ * @extends Request<array<int, Skyhook>>
+ */
+class GetCorporationSkyhooksRequest extends Request
+{
+    public function __construct(public int $corporation_id) {}
+
+    public function resolveEndpoint(): string
+    {
+        return sprintf('/corporations/%d/structures/skyhooks', $this->corporation_id);
+    }
+
+    /**
+     * @return array<int, Skyhook>
+     */
+    public function createDto(Response $response, mixed $data): array
+    {
+        return Skyhook::hydrateList(Data::of($data)->raw('skyhooks'));
+    }
+}

--- a/src/Requests/GetCorporationSovereigntyHubRequest.php
+++ b/src/Requests/GetCorporationSovereigntyHubRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\Requests;
+
+use Illuminate\Http\Client\Response;
+use NicolasKion\Esi\DTO\SovereigntyHub;
+use NicolasKion\Esi\Request;
+
+/**
+ * @extends Request<SovereigntyHub>
+ */
+class GetCorporationSovereigntyHubRequest extends Request
+{
+    public function __construct(
+        public int $corporation_id,
+        public int $sovereignty_hub_id,
+    ) {}
+
+    public function resolveEndpoint(): string
+    {
+        return sprintf('/corporations/%d/structures/sovereignty-hubs/%d', $this->corporation_id, $this->sovereignty_hub_id);
+    }
+
+    public function createDto(Response $response, mixed $data): SovereigntyHub
+    {
+        return SovereigntyHub::hydrate($data);
+    }
+}

--- a/src/Requests/GetCorporationSovereigntyHubsRequest.php
+++ b/src/Requests/GetCorporationSovereigntyHubsRequest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\Requests;
+
+use Illuminate\Http\Client\Response;
+use NicolasKion\Esi\DTO\SovereigntyHub;
+use NicolasKion\Esi\Request;
+use NicolasKion\Esi\Support\Data;
+
+/**
+ * @extends Request<array<int, SovereigntyHub>>
+ */
+class GetCorporationSovereigntyHubsRequest extends Request
+{
+    public function __construct(public int $corporation_id) {}
+
+    public function resolveEndpoint(): string
+    {
+        return sprintf('/corporations/%d/structures/sovereignty-hubs', $this->corporation_id);
+    }
+
+    /**
+     * @return array<int, SovereigntyHub>
+     */
+    public function createDto(Response $response, mixed $data): array
+    {
+        return SovereigntyHub::hydrateList(Data::of($data)->raw('sovereignty_hubs'));
+    }
+}

--- a/src/Requests/GetMercenaryDenRequest.php
+++ b/src/Requests/GetMercenaryDenRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\Requests;
+
+use Illuminate\Http\Client\Response;
+use NicolasKion\Esi\DTO\MercenaryDen;
+use NicolasKion\Esi\Request;
+
+/**
+ * @extends Request<MercenaryDen>
+ */
+class GetMercenaryDenRequest extends Request
+{
+    public function __construct(
+        public int $character_id,
+        public int $mercenary_den_id,
+    ) {}
+
+    public function resolveEndpoint(): string
+    {
+        return sprintf('/characters/%d/structures/mercenary-dens/%d', $this->character_id, $this->mercenary_den_id);
+    }
+
+    public function createDto(Response $response, mixed $data): MercenaryDen
+    {
+        return MercenaryDen::hydrate($data);
+    }
+}

--- a/src/Requests/GetMercenaryDensRequest.php
+++ b/src/Requests/GetMercenaryDensRequest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\Requests;
+
+use Illuminate\Http\Client\Response;
+use NicolasKion\Esi\DTO\MercenaryDen;
+use NicolasKion\Esi\Request;
+use NicolasKion\Esi\Support\Data;
+
+/**
+ * @extends Request<array<int, MercenaryDen>>
+ */
+class GetMercenaryDensRequest extends Request
+{
+    public function __construct(public int $character_id) {}
+
+    public function resolveEndpoint(): string
+    {
+        return sprintf('/characters/%d/structures/mercenary-dens', $this->character_id);
+    }
+
+    /**
+     * @return array<int, MercenaryDen>
+     */
+    public function createDto(Response $response, mixed $data): array
+    {
+        return MercenaryDen::hydrateList(Data::of($data)->raw('mercenary_dens'));
+    }
+}

--- a/tests/StructuresProjectsTest.php
+++ b/tests/StructuresProjectsTest.php
@@ -1,0 +1,360 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Http;
+use NicolasKion\Esi\DTO\CorporationProject;
+use NicolasKion\Esi\DTO\MercenaryDen;
+use NicolasKion\Esi\DTO\ProjectContribution;
+use NicolasKion\Esi\DTO\ProjectContributor;
+use NicolasKion\Esi\DTO\Skyhook;
+use NicolasKion\Esi\DTO\SovereigntyHub;
+use NicolasKion\Esi\Esi;
+
+it('fetches and maps a sparse listing of a character\'s Mercenary Dens', function (): void {
+    Http::fake([
+        'esi.evetech.net/characters/123/structures/mercenary-dens' => Http::response([
+            'mercenary_dens' => [
+                ['id' => 1000000000001, 'planet_id' => 40000002],
+            ],
+        ]),
+    ]);
+
+    $result = (new Esi)->getMercenaryDens(fakeCharacter());
+
+    expect($result->wasSuccessful())->toBeTrue()
+        ->and($result->data)->toHaveCount(1)
+        ->and($result->data[0])->toBeInstanceOf(MercenaryDen::class)
+        ->and($result->data[0]->id)->toBe(1000000000001)
+        ->and($result->data[0]->planet_id)->toBe(40000002)
+        ->and($result->data[0]->state)->toBeNull()
+        ->and($result->data[0]->type_id)->toBeNull()
+        ->and($result->data[0]->skyhook)->toBeNull()
+        ->and($result->data[0]->infomorphs)->toBeNull()
+        ->and($result->data[0]->evolution)->toBeNull()
+        ->and($result->data[0]->reinforcement_timer_end)->toBeNull();
+});
+
+it('fetches and maps the full detail of a character\'s Mercenary Den', function (): void {
+    Http::fake([
+        'esi.evetech.net/characters/123/structures/mercenary-dens/1000000000001' => Http::response([
+            'id' => 1000000000001,
+            'skyhook' => ['id' => 1000000000002, 'planet_id' => 40000003, 'corporation_id' => 98777771],
+            'state' => 'Running',
+            'type_id' => 587,
+            'infomorphs' => ['amount' => 100],
+            'evolution' => [
+                'anarchy' => ['amount' => 0, 'level' => 'Level0'],
+                'development' => ['amount' => 50, 'level' => 'Level2'],
+            ],
+            'reinforcement_timer' => ['end' => '2026-06-09T12:00:00Z'],
+        ]),
+    ]);
+
+    $result = (new Esi)->getMercenaryDen(fakeCharacter(), 1000000000001);
+
+    expect($result->wasSuccessful())->toBeTrue()
+        ->and($result->data)->toBeInstanceOf(MercenaryDen::class)
+        ->and($result->data->id)->toBe(1000000000001)
+        ->and($result->data->planet_id)->toBeNull()
+        ->and($result->data->state)->toBe('Running')
+        ->and($result->data->type_id)->toBe(587)
+        ->and($result->data->skyhook?->id)->toBe(1000000000002)
+        ->and($result->data->skyhook?->planet_id)->toBe(40000003)
+        ->and($result->data->skyhook?->corporation_id)->toBe(98777771)
+        ->and($result->data->infomorphs?->amount)->toBe(100)
+        ->and($result->data->evolution?->anarchy->amount)->toBe(0)
+        ->and($result->data->evolution?->anarchy->level)->toBe('Level0')
+        ->and($result->data->evolution?->development->amount)->toBe(50)
+        ->and($result->data->evolution?->development->level)->toBe('Level2')
+        ->and($result->data->reinforcement_timer_end)->toBe('2026-06-09T12:00:00Z');
+});
+
+it('fetches and maps a sparse listing of a corporation\'s Skyhooks', function (): void {
+    Http::fake([
+        'esi.evetech.net/corporations/456/structures/skyhooks' => Http::response([
+            'skyhooks' => [
+                ['id' => 2000000000001, 'planet_id' => 40000004],
+            ],
+        ]),
+    ]);
+
+    $result = (new Esi)->getCorporationSkyhooks(fakeCharacter(), 456);
+
+    expect($result->wasSuccessful())->toBeTrue()
+        ->and($result->data)->toHaveCount(1)
+        ->and($result->data[0])->toBeInstanceOf(Skyhook::class)
+        ->and($result->data[0]->id)->toBe(2000000000001)
+        ->and($result->data[0]->planet_id)->toBe(40000004)
+        ->and($result->data[0]->effective_workforce)->toBeNull()
+        ->and($result->data[0]->is_active)->toBeNull()
+        ->and($result->data[0]->state)->toBeNull()
+        ->and($result->data[0]->reagents)->toBe([])
+        ->and($result->data[0]->reinforcement_timer_end)->toBeNull()
+        ->and($result->data[0]->theft_vulnerability)->toBeNull();
+});
+
+it('fetches and maps the full detail of a corporation\'s Skyhook', function (): void {
+    Http::fake([
+        'esi.evetech.net/corporations/456/structures/skyhooks/2000000000001' => Http::response([
+            'id' => 2000000000001,
+            'planet_id' => 40000004,
+            'effective_workforce' => 1000,
+            'is_active' => true,
+            'reagents' => [
+                ['type_id' => 587, 'secured_stock' => 1000, 'unsecured_stock' => 300, 'last_cycle' => '2026-02-23T12:00:00Z'],
+            ],
+            'reinforcement_timer' => ['end' => '2026-02-23T16:00:00Z'],
+            'state' => 'ShieldVulnerable',
+            'theft_vulnerability' => ['start' => '2026-02-23T12:00:00Z', 'end' => '2026-02-23T16:00:00Z'],
+        ]),
+    ]);
+
+    $result = (new Esi)->getCorporationSkyhook(fakeCharacter(), 456, 2000000000001);
+
+    expect($result->wasSuccessful())->toBeTrue()
+        ->and($result->data)->toBeInstanceOf(Skyhook::class)
+        ->and($result->data->id)->toBe(2000000000001)
+        ->and($result->data->planet_id)->toBe(40000004)
+        ->and($result->data->effective_workforce)->toBe(1000)
+        ->and($result->data->is_active)->toBeTrue()
+        ->and($result->data->state)->toBe('ShieldVulnerable')
+        ->and($result->data->reagents)->toHaveCount(1)
+        ->and($result->data->reagents[0]->type_id)->toBe(587)
+        ->and($result->data->reagents[0]->secured_stock)->toBe(1000)
+        ->and($result->data->reagents[0]->unsecured_stock)->toBe(300)
+        ->and($result->data->reagents[0]->last_cycle)->toBe('2026-02-23T12:00:00Z')
+        ->and($result->data->reinforcement_timer_end)->toBe('2026-02-23T16:00:00Z')
+        ->and($result->data->theft_vulnerability?->start)->toBe('2026-02-23T12:00:00Z')
+        ->and($result->data->theft_vulnerability?->end)->toBe('2026-02-23T16:00:00Z');
+});
+
+it('fetches and maps a sparse listing of a corporation\'s Sovereignty Hubs', function (): void {
+    Http::fake([
+        'esi.evetech.net/corporations/456/structures/sovereignty-hubs' => Http::response([
+            'sovereignty_hubs' => [
+                ['id' => 3000000000001, 'solar_system_id' => 30000001],
+            ],
+        ]),
+    ]);
+
+    $result = (new Esi)->getCorporationSovereigntyHubs(fakeCharacter(), 456);
+
+    expect($result->wasSuccessful())->toBeTrue()
+        ->and($result->data)->toHaveCount(1)
+        ->and($result->data[0])->toBeInstanceOf(SovereigntyHub::class)
+        ->and($result->data[0]->id)->toBe(3000000000001)
+        ->and($result->data[0]->solar_system_id)->toBe(30000001)
+        ->and($result->data[0]->fuel_access_list_id)->toBeNull()
+        ->and($result->data[0]->reagent_bay)->toBeNull()
+        ->and($result->data[0]->resources)->toBeNull()
+        ->and($result->data[0]->upgrades)->toBe([])
+        ->and($result->data[0]->vulnerability_window)->toBeNull()
+        ->and($result->data[0]->workforce_transport)->toBeNull();
+});
+
+it('fetches and maps the full detail of a corporation\'s Sovereignty Hub', function (): void {
+    Http::fake([
+        'esi.evetech.net/corporations/456/structures/sovereignty-hubs/3000000000001' => Http::response([
+            'fuel_access_list_id' => 1,
+            'id' => 3000000000001,
+            'reagent_bay' => [
+                'last_updated' => '2026-02-23T12:00:00Z',
+                'reagents' => [
+                    ['amount' => 1000, 'burning_per_hour' => 10, 'type_id' => 587],
+                ],
+            ],
+            'resources' => [
+                'power' => ['allocated' => 100, 'available' => 1000],
+                'workforce' => ['allocated' => 200, 'available' => 2000],
+            ],
+            'solar_system_id' => 30000001,
+            'upgrades' => [
+                ['power_state' => 'Online', 'type_id' => 587],
+            ],
+            'vulnerability_window' => ['start' => '2026-02-23T12:00:00Z', 'end' => '2026-02-23T16:00:00Z'],
+            'workforce_transport' => [
+                'configuration' => [
+                    'import' => ['sources' => [['solar_system_id' => 30000002]]],
+                ],
+                'state' => [
+                    'export' => ['amount' => 500, 'solar_system_id' => 30000003],
+                ],
+            ],
+        ]),
+    ]);
+
+    $result = (new Esi)->getCorporationSovereigntyHub(fakeCharacter(), 456, 3000000000001);
+
+    expect($result->wasSuccessful())->toBeTrue()
+        ->and($result->data)->toBeInstanceOf(SovereigntyHub::class)
+        ->and($result->data->id)->toBe(3000000000001)
+        ->and($result->data->solar_system_id)->toBe(30000001)
+        ->and($result->data->fuel_access_list_id)->toBe(1)
+        ->and($result->data->reagent_bay?->last_updated)->toBe('2026-02-23T12:00:00Z')
+        ->and($result->data->reagent_bay?->reagents)->toHaveCount(1)
+        ->and($result->data->reagent_bay?->reagents[0]->amount)->toBe(1000)
+        ->and($result->data->reagent_bay?->reagents[0]->burning_per_hour)->toBe(10)
+        ->and($result->data->reagent_bay?->reagents[0]->type_id)->toBe(587)
+        ->and($result->data->resources?->power->allocated)->toBe(100)
+        ->and($result->data->resources?->power->available)->toBe(1000)
+        ->and($result->data->resources?->workforce->allocated)->toBe(200)
+        ->and($result->data->resources?->workforce->available)->toBe(2000)
+        ->and($result->data->upgrades)->toHaveCount(1)
+        ->and($result->data->upgrades[0]->power_state)->toBe('Online')
+        ->and($result->data->upgrades[0]->type_id)->toBe(587)
+        ->and($result->data->vulnerability_window?->start)->toBe('2026-02-23T12:00:00Z')
+        ->and($result->data->vulnerability_window?->end)->toBe('2026-02-23T16:00:00Z')
+        ->and($result->data->workforce_transport?->configuration?->import?->sources[0]->solar_system_id)->toBe(30000002)
+        ->and($result->data->workforce_transport?->configuration?->import?->sources[0]->amount)->toBeNull()
+        ->and($result->data->workforce_transport?->configuration?->export)->toBeNull()
+        ->and($result->data->workforce_transport?->configuration?->transit)->toBeNull()
+        ->and($result->data->workforce_transport?->state?->export?->amount)->toBe(500)
+        ->and($result->data->workforce_transport?->state?->export?->solar_system_id)->toBe(30000003)
+        ->and($result->data->workforce_transport?->state?->import)->toBeNull();
+});
+
+it('fetches and maps a listing of corporation projects', function (): void {
+    Http::fake([
+        'esi.evetech.net/corporations/456/projects' => Http::response([
+            'cursor' => ['after' => 'a', 'before' => 'b'],
+            'projects' => [
+                [
+                    'id' => '3868eaed-8278-4cb7-9709-7d7de9c20dc7',
+                    'last_modified' => '2025-06-01T00:00:00Z',
+                    'name' => 'Project Name',
+                    'progress' => ['current' => 50, 'desired' => 100],
+                    'reward' => ['initial' => 12345.5, 'remaining' => 5432.1],
+                    'state' => 'Active',
+                ],
+            ],
+        ]),
+    ]);
+
+    $result = (new Esi)->getCorporationProjects(fakeCharacter(), 456);
+
+    expect($result->wasSuccessful())->toBeTrue()
+        ->and($result->data)->toHaveCount(1)
+        ->and($result->data[0])->toBeInstanceOf(CorporationProject::class)
+        ->and($result->data[0]->id)->toBe('3868eaed-8278-4cb7-9709-7d7de9c20dc7')
+        ->and($result->data[0]->name)->toBe('Project Name')
+        ->and($result->data[0]->state)->toBe('Active')
+        ->and($result->data[0]->last_modified)->toBe('2025-06-01T00:00:00Z')
+        ->and($result->data[0]->progress->current)->toBe(50)
+        ->and($result->data[0]->progress->desired)->toBe(100)
+        ->and($result->data[0]->reward?->initial)->toBe(12345.5)
+        ->and($result->data[0]->reward?->remaining)->toBe(5432.1)
+        ->and($result->data[0]->creator)->toBeNull()
+        ->and($result->data[0]->details)->toBeNull()
+        ->and($result->data[0]->configuration)->toBeNull()
+        ->and($result->data[0]->contribution)->toBeNull();
+});
+
+it('fetches and maps the full detail of a corporation project', function (): void {
+    Http::fake([
+        'esi.evetech.net/corporations/456/projects/3868eaed-8278-4cb7-9709-7d7de9c20dc7' => Http::response([
+            'configuration' => [
+                'capture_fw_complex' => [
+                    'archetypes' => [['archetype_id' => 33]],
+                    'factions' => [['faction_id' => 500002]],
+                    'locations' => [['solar_system_id' => 30000001]],
+                ],
+            ],
+            'contribution' => [
+                'participation_limit' => 1000,
+                'reward_per_contribution' => 123.5,
+                'submission_limit' => 100,
+                'submission_multiplier' => 1.5,
+            ],
+            'creator' => ['id' => 90000001, 'name' => 'Creator Name'],
+            'details' => [
+                'career' => 'Explorer',
+                'created' => '2025-06-01T00:00:00Z',
+                'description' => 'Project Description',
+                'expires' => '2025-06-01T00:01:00Z',
+                'finished' => '2025-06-01T00:00:00Z',
+            ],
+            'id' => '3868eaed-8278-4cb7-9709-7d7de9c20dc7',
+            'last_modified' => '2025-06-01T00:00:00Z',
+            'name' => 'Project Name',
+            'progress' => ['current' => 50, 'desired' => 100],
+            'reward' => ['initial' => 12345.5, 'remaining' => 5432.1],
+            'state' => 'Active',
+        ]),
+    ]);
+
+    $result = (new Esi)->getCorporationProject(fakeCharacter(), 456, '3868eaed-8278-4cb7-9709-7d7de9c20dc7');
+
+    expect($result->wasSuccessful())->toBeTrue()
+        ->and($result->data)->toBeInstanceOf(CorporationProject::class)
+        ->and($result->data->id)->toBe('3868eaed-8278-4cb7-9709-7d7de9c20dc7')
+        ->and($result->data->name)->toBe('Project Name')
+        ->and($result->data->state)->toBe('Active')
+        ->and($result->data->progress->current)->toBe(50)
+        ->and($result->data->reward?->initial)->toBe(12345.5)
+        ->and($result->data->creator?->id)->toBe(90000001)
+        ->and($result->data->creator?->name)->toBe('Creator Name')
+        ->and($result->data->details?->career)->toBe('Explorer')
+        ->and($result->data->details?->created)->toBe('2025-06-01T00:00:00Z')
+        ->and($result->data->details?->description)->toBe('Project Description')
+        ->and($result->data->details?->expires)->toBe('2025-06-01T00:01:00Z')
+        ->and($result->data->details?->finished)->toBe('2025-06-01T00:00:00Z')
+        ->and($result->data->configuration)->toBe([
+            'capture_fw_complex' => [
+                'archetypes' => [['archetype_id' => 33]],
+                'factions' => [['faction_id' => 500002]],
+                'locations' => [['solar_system_id' => 30000001]],
+            ],
+        ])
+        ->and($result->data->contribution?->participation_limit)->toBe(1000)
+        ->and($result->data->contribution?->reward_per_contribution)->toBe(123.5)
+        ->and($result->data->contribution?->submission_limit)->toBe(100)
+        ->and($result->data->contribution?->submission_multiplier)->toBe(1.5);
+});
+
+it('fetches and maps a character\'s contribution to a corporation project', function (): void {
+    Http::fake([
+        'esi.evetech.net/corporations/456/projects/3868eaed-8278-4cb7-9709-7d7de9c20dc7/contribution/90000002' => Http::response([
+            'contributed' => 10,
+            'last_modified' => '2025-08-26T00:00:00Z',
+        ]),
+    ]);
+
+    $result = (new Esi)->getCorporationProjectContribution(fakeCharacter(), 456, '3868eaed-8278-4cb7-9709-7d7de9c20dc7', 90000002);
+
+    expect($result->wasSuccessful())->toBeTrue()
+        ->and($result->data)->toBeInstanceOf(ProjectContribution::class)
+        ->and($result->data->contributed)->toBe(10)
+        ->and($result->data->last_modified)->toBe('2025-08-26T00:00:00Z');
+});
+
+it('fetches and maps the contributors to a corporation project', function (): void {
+    Http::fake([
+        'esi.evetech.net/corporations/456/projects/3868eaed-8278-4cb7-9709-7d7de9c20dc7/contributors' => Http::response([
+            'contributors' => [
+                ['contributed' => 10, 'id' => 90000001, 'name' => 'Contributor Name'],
+            ],
+            'cursor' => ['after' => 'a', 'before' => 'b'],
+        ]),
+    ]);
+
+    $result = (new Esi)->getCorporationProjectContributors(fakeCharacter(), 456, '3868eaed-8278-4cb7-9709-7d7de9c20dc7');
+
+    expect($result->wasSuccessful())->toBeTrue()
+        ->and($result->data)->toHaveCount(1)
+        ->and($result->data[0])->toBeInstanceOf(ProjectContributor::class)
+        ->and($result->data[0]->id)->toBe(90000001)
+        ->and($result->data[0]->name)->toBe('Contributor Name')
+        ->and($result->data[0]->contributed)->toBe(10);
+});
+
+it('returns an error result when a structures/projects endpoint fails with a server error', function (): void {
+    Http::fake([
+        'esi.evetech.net/corporations/456/structures/skyhooks' => Http::response(['error' => 'Internal server error'], 500),
+    ]);
+
+    $result = (new Esi)->getCorporationSkyhooks(fakeCharacter(), 456);
+
+    expect($result->failed())->toBeTrue()
+        ->and($result->error?->code)->toBe(500);
+});


### PR DESCRIPTION
Structures (mercenary dens, skyhooks, sovereignty hubs — list + detail) and Corporation Projects (list/detail/contribution/contributors). ~27 DTOs, 3 scopes. PHPStan level 9 clean, 100% coverage (305 tests).