### PR TITLE
feat: automatically walk ESI cursor-paginated endpoints

### DIFF
--- a/src/Connector.php
+++ b/src/Connector.php
@@ -15,7 +15,9 @@ use NicolasKion\Esi\DTO\EsiStats;
 use NicolasKion\Esi\Enums\RequestMethod;
 use NicolasKion\Esi\Interfaces\EsiToken;
 use NicolasKion\Esi\Interfaces\WithBody;
+use NicolasKion\Esi\Interfaces\WithCursorPagination;
 use NicolasKion\Esi\Interfaces\WithPagination;
+use NicolasKion\Esi\Support\Data;
 use Throwable;
 
 use function config;
@@ -143,6 +145,78 @@ class Connector
 
             $results = array_merge($results, $request->createDto($response, $this->normalizeJson($response)));
         } while ($request->hasMorePages($page, $response));
+
+        return new EsiResult(
+            stats: $this->getStatsFromResponse($response),
+            data: $results,
+        );
+    }
+
+    /**
+     * @template T
+     *
+     * @param  WithCursorPagination<array<int, T>>  $request
+     * @return EsiResult<array<int, T>>
+     */
+    public function sendCursorPaginated(WithCursorPagination $request): EsiResult
+    {
+        if ($this->error) {
+            return EsiResult::fromError($this->error);
+        }
+
+        $results = [];
+
+        $token = $this->token;
+
+        $after = null;
+
+        // Cursors we have already requested. Guards against a non-advancing
+        // cursor (e.g. an API that keeps handing back the same `after`) turning
+        // the walk into an infinite loop.
+        $requested_cursors = [];
+
+        do {
+            // Stop if the API points us back at a cursor we have already
+            // fetched — otherwise we would loop forever on the same page.
+            if (in_array($after, $requested_cursors, true)) {
+                break;
+            }
+
+            $requested_cursors[] = $after;
+
+            $pending_request = Http::withHeaders([
+                'User-Agent' => config()->string('esi.user_agent'),
+                'X-Compatibility-Date' => self::COMPATIBILITY_DATE,
+            ])
+                ->baseUrl(config()->string('esi.base_url'))
+                ->when(count($request->getQuery()), fn (PendingRequest $r) => $r->withQueryParameters($request->getQuery()))
+                ->when($after !== null, fn (PendingRequest $r) => $r->withQueryParameters(['after' => (string) $after]))
+                ->when(count($request->getHeaders()), fn (PendingRequest $r) => $r->withHeaders($request->getHeaders()))
+                ->when($token !== null, fn (PendingRequest $r) => $r->withToken((string) $token?->getAccessToken()))
+                ->retry(
+                    times: config()->integer('esi.retry_policy.tries'),
+                    sleepMilliseconds: config()->integer('esi.retry_policy.delay'),
+                    when: fn (Throwable $e, PendingRequest $pendingRequest) => $e instanceof RequestException && $request->shouldRetry($e->response),
+                    throw: false
+                );
+
+            try {
+                // Cursor-paginated endpoints are always GET.
+                $response = $pending_request->get($request->resolveEndpoint());
+            } catch (ConnectionException $e) {
+                return EsiResult::fromError(new EsiError(code: 500, body: $e->getMessage()));
+            }
+
+            if ($response->failed()) {
+                return $this->handleFailedResponse($response);
+            }
+
+            $data = $this->normalizeJson($response);
+            $results = array_merge($results, $request->createDto($response, $data));
+
+            // Walk forward until the API stops handing back an `after` cursor.
+            $after = Data::of($data)->object('cursor')->string('after');
+        } while ($after !== null && $after !== '');
 
         return new EsiResult(
             stats: $this->getStatsFromResponse($response),

--- a/src/Esi.php
+++ b/src/Esi.php
@@ -3045,7 +3045,7 @@ class Esi
         $connector = $this->getAuthenticatedConnector($character, EsiScope::ReadCorporationProjects);
         $request = new GetCorporationProjectsRequest($corporation_id);
 
-        return $connector->send($request);
+        return $connector->sendCursorPaginated($request);
     }
 
     /**
@@ -3084,7 +3084,7 @@ class Esi
         $connector = $this->getAuthenticatedConnector($character, EsiScope::ReadCorporationProjects);
         $request = new GetCorporationProjectContributorsRequest($corporation_id, $project_id);
 
-        return $connector->send($request);
+        return $connector->sendCursorPaginated($request);
     }
 
     /**
@@ -3217,7 +3217,7 @@ class Esi
         $connector = new Connector;
         $request = new GetFreelanceJobsRequest;
 
-        return $connector->send($request);
+        return $connector->sendCursorPaginated($request);
     }
 
     /**
@@ -3269,7 +3269,7 @@ class Esi
         $connector = $this->getAuthenticatedConnector($character, EsiScope::ReadCorporationFreelanceJobs);
         $request = new GetCorporationFreelanceJobsRequest($corporation_id);
 
-        return $connector->send($request);
+        return $connector->sendCursorPaginated($request);
     }
 
     /**
@@ -3282,7 +3282,7 @@ class Esi
         $connector = $this->getAuthenticatedConnector($character, EsiScope::ReadCorporationFreelanceJobs);
         $request = new GetCorporationFreelanceJobParticipantsRequest($corporation_id, $job_id);
 
-        return $connector->send($request);
+        return $connector->sendCursorPaginated($request);
     }
 
     private function getAuthenticatedConnector(Character $character, EsiScope $scope): Connector

--- a/src/Interfaces/WithCursorPagination.php
+++ b/src/Interfaces/WithCursorPagination.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NicolasKion\Esi\Interfaces;
+
+/**
+ * Marks a request whose endpoint uses ESI cursor pagination: the response
+ * carries a `cursor` object ({after, before}) and the next page is fetched by
+ * passing `?after=<cursor.after>` until `after` is empty. The request's
+ * createDto() unwraps and hydrates the page's items.
+ *
+ * @template-covariant TData
+ *
+ * @extends Request<TData>
+ */
+interface WithCursorPagination extends Request {}

--- a/src/Requests/GetCorporationFreelanceJobParticipantsRequest.php
+++ b/src/Requests/GetCorporationFreelanceJobParticipantsRequest.php
@@ -6,13 +6,16 @@ namespace NicolasKion\Esi\Requests;
 
 use Illuminate\Http\Client\Response;
 use NicolasKion\Esi\DTO\FreelanceJobParticipant;
+use NicolasKion\Esi\Interfaces\WithCursorPagination;
 use NicolasKion\Esi\Request;
 use NicolasKion\Esi\Support\Data;
 
 /**
  * @extends Request<array<int, FreelanceJobParticipant>>
+ *
+ * @implements WithCursorPagination<array<int, FreelanceJobParticipant>>
  */
-class GetCorporationFreelanceJobParticipantsRequest extends Request
+class GetCorporationFreelanceJobParticipantsRequest extends Request implements WithCursorPagination
 {
     public function __construct(
         public int $corporation_id,

--- a/src/Requests/GetCorporationFreelanceJobsRequest.php
+++ b/src/Requests/GetCorporationFreelanceJobsRequest.php
@@ -6,13 +6,16 @@ namespace NicolasKion\Esi\Requests;
 
 use Illuminate\Http\Client\Response;
 use NicolasKion\Esi\DTO\FreelanceJob;
+use NicolasKion\Esi\Interfaces\WithCursorPagination;
 use NicolasKion\Esi\Request;
 use NicolasKion\Esi\Support\Data;
 
 /**
  * @extends Request<array<int, FreelanceJob>>
+ *
+ * @implements WithCursorPagination<array<int, FreelanceJob>>
  */
-class GetCorporationFreelanceJobsRequest extends Request
+class GetCorporationFreelanceJobsRequest extends Request implements WithCursorPagination
 {
     public function __construct(public int $corporation_id) {}
 

--- a/src/Requests/GetCorporationProjectContributorsRequest.php
+++ b/src/Requests/GetCorporationProjectContributorsRequest.php
@@ -6,13 +6,16 @@ namespace NicolasKion\Esi\Requests;
 
 use Illuminate\Http\Client\Response;
 use NicolasKion\Esi\DTO\ProjectContributor;
+use NicolasKion\Esi\Interfaces\WithCursorPagination;
 use NicolasKion\Esi\Request;
 use NicolasKion\Esi\Support\Data;
 
 /**
  * @extends Request<array<int, ProjectContributor>>
+ *
+ * @implements WithCursorPagination<array<int, ProjectContributor>>
  */
-class GetCorporationProjectContributorsRequest extends Request
+class GetCorporationProjectContributorsRequest extends Request implements WithCursorPagination
 {
     public function __construct(
         public int $corporation_id,

--- a/src/Requests/GetCorporationProjectsRequest.php
+++ b/src/Requests/GetCorporationProjectsRequest.php
@@ -6,13 +6,16 @@ namespace NicolasKion\Esi\Requests;
 
 use Illuminate\Http\Client\Response;
 use NicolasKion\Esi\DTO\CorporationProject;
+use NicolasKion\Esi\Interfaces\WithCursorPagination;
 use NicolasKion\Esi\Request;
 use NicolasKion\Esi\Support\Data;
 
 /**
  * @extends Request<array<int, CorporationProject>>
+ *
+ * @implements WithCursorPagination<array<int, CorporationProject>>
  */
-class GetCorporationProjectsRequest extends Request
+class GetCorporationProjectsRequest extends Request implements WithCursorPagination
 {
     public function __construct(public int $corporation_id) {}
 

--- a/src/Requests/GetFreelanceJobsRequest.php
+++ b/src/Requests/GetFreelanceJobsRequest.php
@@ -6,13 +6,16 @@ namespace NicolasKion\Esi\Requests;
 
 use Illuminate\Http\Client\Response;
 use NicolasKion\Esi\DTO\FreelanceJob;
+use NicolasKion\Esi\Interfaces\WithCursorPagination;
 use NicolasKion\Esi\Request;
 use NicolasKion\Esi\Support\Data;
 
 /**
  * @extends Request<array<int, FreelanceJob>>
+ *
+ * @implements WithCursorPagination<array<int, FreelanceJob>>
  */
-class GetFreelanceJobsRequest extends Request
+class GetFreelanceJobsRequest extends Request implements WithCursorPagination
 {
     public function resolveEndpoint(): string
     {

--- a/tests/ConnectorTest.php
+++ b/tests/ConnectorTest.php
@@ -6,78 +6,10 @@ use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Http\Client\Response;
 use Illuminate\Support\Facades\Http;
 use NicolasKion\Esi\Connector;
-use NicolasKion\Esi\Enums\EsiScope;
 use NicolasKion\Esi\Enums\RequestMethod;
 use NicolasKion\Esi\Esi;
-use NicolasKion\Esi\Interfaces\Character;
-use NicolasKion\Esi\Interfaces\EsiToken;
 use NicolasKion\Esi\Interfaces\WithBody;
 use NicolasKion\Esi\Request;
-
-/**
- * A token whose expiry, updates and deletion are observable from the test.
- */
-function trackedToken(bool $expired = false): EsiToken
-{
-    return new class($expired) implements EsiToken
-    {
-        /** @var array<string, mixed> */
-        public array $updated = [];
-
-        public bool $deleted = false;
-
-        public function __construct(private bool $expired) {}
-
-        public function isExpired(): bool
-        {
-            return $this->expired;
-        }
-
-        public function getRefreshToken(): string
-        {
-            return 'refresh-token';
-        }
-
-        public function getAccessToken(): string
-        {
-            return 'access-token';
-        }
-
-        public function delete(): void
-        {
-            $this->deleted = true;
-        }
-
-        public function update(array $data): void
-        {
-            $this->updated = $data;
-            $this->expired = false;
-        }
-    };
-}
-
-function characterFor(EsiToken $token): Character
-{
-    return new class($token) implements Character
-    {
-        public function __construct(private EsiToken $token) {}
-
-        public function getEsiTokenWithScope(EsiScope $scope): ?EsiToken
-        {
-            return $this->token;
-        }
-
-        public function getId(): int
-        {
-            return 123;
-        }
-
-        public function getCorporationId(): int
-        {
-            return 456;
-        }
-    };
-}
 
 beforeEach(function (): void {
     config()->set('esi.client_id', 'client-id');

--- a/tests/CursorPaginationTest.php
+++ b/tests/CursorPaginationTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Support\Facades\Http;
+use NicolasKion\Esi\Esi;
+
+it('walks cursor pages until the after cursor is empty', function (): void {
+    Http::fakeSequence('esi.evetech.net/corporations/456/projects/*/contributors*')
+        ->push(['cursor' => ['after' => 'CURSOR2'], 'contributors' => [['id' => 1, 'name' => 'A', 'contributed' => 10]]], 200)
+        ->push(['cursor' => ['after' => ''], 'contributors' => [['id' => 2, 'name' => 'B', 'contributed' => 20]]], 200);
+
+    $result = (new Esi)->getCorporationProjectContributors(fakeCharacter(), 456, 'project-uuid');
+
+    // Both pages are merged into a single result set.
+    expect($result->wasSuccessful())->toBeTrue()
+        ->and($result->data)->toHaveCount(2)
+        ->and($result->data[0]->id)->toBe(1)
+        ->and($result->data[1]->id)->toBe(2);
+
+    // The second request forwards the `after` cursor returned by the first.
+    Http::assertSent(fn ($request) => str_contains($request->url(), 'after=CURSOR2'));
+});
+
+it('stops after a single page when no after cursor is returned', function (): void {
+    Http::fake([
+        'esi.evetech.net/corporations/456/projects/*/contributors*' => Http::response([
+            'cursor' => [],
+            'contributors' => [['id' => 7, 'name' => 'Solo', 'contributed' => 1]],
+        ]),
+    ]);
+
+    $result = (new Esi)->getCorporationProjectContributors(fakeCharacter(), 456, 'project-uuid');
+
+    expect($result->wasSuccessful())->toBeTrue()
+        ->and($result->data)->toHaveCount(1);
+
+    Http::assertSentCount(1);
+});
+
+it('stops walking when the API keeps handing back the same cursor', function (): void {
+    // A misbehaving endpoint that never advances its `after` cursor would loop
+    // forever without the connector's non-advancing-cursor guard.
+    Http::fake([
+        'esi.evetech.net/corporations/456/projects/*/contributors*' => Http::response([
+            'cursor' => ['after' => 'STUCK'],
+            'contributors' => [['id' => 1, 'name' => 'A', 'contributed' => 10]],
+        ]),
+    ]);
+
+    $result = (new Esi)->getCorporationProjectContributors(fakeCharacter(), 456, 'project-uuid');
+
+    // The guard breaks the loop after re-encountering the `STUCK` cursor, so we
+    // get the pages fetched before the repeat rather than an infinite loop.
+    expect($result->wasSuccessful())->toBeTrue()
+        ->and($result->data)->toHaveCount(2);
+
+    // Two distinct requests were made (initial + one `after=STUCK`) before the
+    // guard recognised the repeated cursor and stopped.
+    Http::assertSentCount(2);
+});
+
+it('returns a 500 error result when a cursor request throws a connection exception', function (): void {
+    Http::fake([
+        'esi.evetech.net/freelance-jobs*' => fn () => throw new ConnectionException('freelance-jobs unreachable'),
+    ]);
+
+    $result = (new Esi)->getFreelanceJobs();
+
+    expect($result->failed())->toBeTrue()
+        ->and($result->error?->code)->toBe(500);
+});
+
+it('short-circuits a cursor request when the connector already has an error', function (): void {
+    config()->set('esi.client_id', 'client-id');
+    config()->set('esi.client_secret', 'client-secret');
+
+    $token = trackedToken(expired: true);
+
+    Http::fake([
+        'login.eveonline.com/*' => Http::response(['error' => 'invalid_grant'], 400),
+    ]);
+
+    $result = (new Esi)->getCorporationProjectContributors(characterFor($token), 456, 'project-uuid');
+
+    expect($result->failed())->toBeTrue()
+        ->and($token->deleted)->toBeTrue();
+});

--- a/tests/MetaSearchFreelanceTest.php
+++ b/tests/MetaSearchFreelanceTest.php
@@ -287,7 +287,9 @@ it('returns an error result when fetching mercenary tactical operations fails', 
 
 it('fetches and maps the public freelance jobs listing', function (): void {
     Http::fake([
-        'esi.evetech.net/freelance-jobs*' => Http::response(esiFixture('freelance/jobs.json')),
+        'esi.evetech.net/freelance-jobs*' => Http::sequence()
+            ->push(esiFixture('freelance/jobs.json'))
+            ->push(['cursor' => ['after' => ''], 'freelance_jobs' => []]),
     ]);
 
     $result = (new Esi)->getFreelanceJobs();
@@ -371,7 +373,9 @@ it("fetches and maps a character's participation in a freelance job", function (
 
 it('fetches and maps the freelance jobs created by a corporation', function (): void {
     Http::fake([
-        'esi.evetech.net/corporations/456/freelance-jobs*' => Http::response(esiFixture('freelance/jobs.json')),
+        'esi.evetech.net/corporations/456/freelance-jobs*' => Http::sequence()
+            ->push(esiFixture('freelance/jobs.json'))
+            ->push(['cursor' => ['after' => ''], 'freelance_jobs' => []]),
     ]);
 
     $result = (new Esi)->getCorporationFreelanceJobs(fakeCharacter(), 456);
@@ -384,7 +388,9 @@ it('fetches and maps the freelance jobs created by a corporation', function (): 
 
 it("fetches and maps a corporation's freelance job participants", function (): void {
     Http::fake([
-        'esi.evetech.net/corporations/456/freelance-jobs/3868eaed-8278-4cb7-9709-7d7de9c20dc7/participants*' => Http::response(esiFixture('freelance/participants.json')),
+        'esi.evetech.net/corporations/456/freelance-jobs/3868eaed-8278-4cb7-9709-7d7de9c20dc7/participants*' => Http::sequence()
+            ->push(esiFixture('freelance/participants.json'))
+            ->push(['cursor' => ['after' => ''], 'participants' => []]),
     ]);
 
     $result = (new Esi)->getCorporationFreelanceJobParticipants(fakeCharacter(), 456, '3868eaed-8278-4cb7-9709-7d7de9c20dc7');

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -102,3 +102,71 @@ function fakeCharacter(int $id = 123, int $corporationId = 456): Character
         }
     };
 }
+
+/**
+ * A token whose expiry, updates and deletion are observable from the test.
+ */
+function trackedToken(bool $expired = false): EsiToken
+{
+    return new class($expired) implements EsiToken
+    {
+        /** @var array<string, mixed> */
+        public array $updated = [];
+
+        public bool $deleted = false;
+
+        public function __construct(private bool $expired) {}
+
+        public function isExpired(): bool
+        {
+            return $this->expired;
+        }
+
+        public function getRefreshToken(): string
+        {
+            return 'refresh-token';
+        }
+
+        public function getAccessToken(): string
+        {
+            return 'access-token';
+        }
+
+        public function delete(): void
+        {
+            $this->deleted = true;
+        }
+
+        public function update(array $data): void
+        {
+            $this->updated = $data;
+            $this->expired = false;
+        }
+    };
+}
+
+/**
+ * Wrap a token in a Character that hands it back for any requested scope.
+ */
+function characterFor(EsiToken $token): Character
+{
+    return new class($token) implements Character
+    {
+        public function __construct(private EsiToken $token) {}
+
+        public function getEsiTokenWithScope(EsiScope $scope): ?EsiToken
+        {
+            return $this->token;
+        }
+
+        public function getId(): int
+        {
+            return 123;
+        }
+
+        public function getCorporationId(): int
+        {
+            return 456;
+        }
+    };
+}

--- a/tests/StructuresProjectsTest.php
+++ b/tests/StructuresProjectsTest.php
@@ -216,19 +216,21 @@ it('fetches and maps the full detail of a corporation\'s Sovereignty Hub', funct
 
 it('fetches and maps a listing of corporation projects', function (): void {
     Http::fake([
-        'esi.evetech.net/corporations/456/projects' => Http::response([
-            'cursor' => ['after' => 'a', 'before' => 'b'],
-            'projects' => [
-                [
-                    'id' => '3868eaed-8278-4cb7-9709-7d7de9c20dc7',
-                    'last_modified' => '2025-06-01T00:00:00Z',
-                    'name' => 'Project Name',
-                    'progress' => ['current' => 50, 'desired' => 100],
-                    'reward' => ['initial' => 12345.5, 'remaining' => 5432.1],
-                    'state' => 'Active',
+        'esi.evetech.net/corporations/456/projects*' => Http::sequence()
+            ->push([
+                'cursor' => ['after' => 'a', 'before' => 'b'],
+                'projects' => [
+                    [
+                        'id' => '3868eaed-8278-4cb7-9709-7d7de9c20dc7',
+                        'last_modified' => '2025-06-01T00:00:00Z',
+                        'name' => 'Project Name',
+                        'progress' => ['current' => 50, 'desired' => 100],
+                        'reward' => ['initial' => 12345.5, 'remaining' => 5432.1],
+                        'state' => 'Active',
+                    ],
                 ],
-            ],
-        ]),
+            ])
+            ->push(['cursor' => ['after' => ''], 'projects' => []]),
     ]);
 
     $result = (new Esi)->getCorporationProjects(fakeCharacter(), 456);
@@ -330,12 +332,14 @@ it('fetches and maps a character\'s contribution to a corporation project', func
 
 it('fetches and maps the contributors to a corporation project', function (): void {
     Http::fake([
-        'esi.evetech.net/corporations/456/projects/3868eaed-8278-4cb7-9709-7d7de9c20dc7/contributors' => Http::response([
-            'contributors' => [
-                ['contributed' => 10, 'id' => 90000001, 'name' => 'Contributor Name'],
-            ],
-            'cursor' => ['after' => 'a', 'before' => 'b'],
-        ]),
+        'esi.evetech.net/corporations/456/projects/3868eaed-8278-4cb7-9709-7d7de9c20dc7/contributors*' => Http::sequence()
+            ->push([
+                'contributors' => [
+                    ['contributed' => 10, 'id' => 90000001, 'name' => 'Contributor Name'],
+                ],
+                'cursor' => ['after' => 'a', 'before' => 'b'],
+            ])
+            ->push(['contributors' => [], 'cursor' => ['after' => '']]),
     ]);
 
     $result = (new Esi)->getCorporationProjectContributors(fakeCharacter(), 456, '3868eaed-8278-4cb7-9709-7d7de9c20dc7');


### PR DESCRIPTION
## Summary

ESI's newest endpoints (freelance jobs and corporation projects) use **cursor pagination** — the response carries a `cursor.after` value and the next page is fetched with `?after=<cursor>` until `after` is empty. Previously these endpoints were called with a single `send()`, so callers silently got only the first page.

This PR adds first-class cursor pagination support and wires all five cursor endpoints to it.

### What changed

- **`WithCursorPagination` interface** — marks a request whose endpoint uses cursor pagination.
- **`Connector::sendCursorPaginated()`** — walks pages, forwarding the `after` cursor and merging every page into one result set. Includes a **non-advancing-cursor guard**: if the API ever returns a cursor that was already requested, the walk stops instead of looping forever (protects against a misbehaving live API hanging the caller).
- **Five endpoints wired** to the new method:
  - `GET /freelance-jobs`
  - `GET /corporations/{id}/freelance-jobs`
  - `GET /corporations/{id}/freelance-jobs/{job}/participants`
  - `GET /corporations/{id}/projects`
  - `GET /corporations/{id}/projects/{pid}/contributors`

### Tests

- New `CursorPaginationTest` covers multi-page walking, single-page termination, the non-advancing-cursor guard, connection failures, and the connector error short-circuit.
- Existing project/freelance fakes converted to `Http::sequence()` (first page with a populated cursor → terminal empty-cursor page) so they model real paginated responses. The old static fakes returned a non-empty cursor on every request, which is what caused the walk to never terminate.
- Shared `trackedToken()` / `characterFor()` helpers moved into `tests/Pest.php` so `CursorPaginationTest` runs standalone.

### Verification

- ✅ `pest`: 333 passed (2010 assertions)
- ✅ Coverage: **100.0%** (`--min=100` gate passes)
- ✅ `phpstan analyse`: no errors
- ✅ `pint --test`: passed
- ✅ Endpoint audit vs bundled OpenAPI spec: **218 spec operations ↔ 218 request classes**, clean bijection (nothing missing/stale); the 5 cursor endpoints verified by both `after`/`before` params and `cursor` response shape.
- ✅ No spec drift: the bundled `tools/fixtures/openapi.json` is byte-for-byte identical to live ESI at compatibility date `2026-06-09`.