### PR TITLE
ci: open a changelog PR from the release workflow instead of pushing to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,9 +24,6 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: main
-          # Deploy key so the changelog commit can bypass the required status
-          # checks on main (GITHUB_TOKEN pushes are rejected by the ruleset).
-          ssh-key: ${{ secrets.COMMIT_SSH_KEY }}
 
       - name: Create release
         uses: softprops/action-gh-release@v3
@@ -53,9 +50,24 @@ jobs:
           latest-version: ${{ inputs.tag || github.ref_name }}
           release-notes: ${{ steps.notes.outputs.body }}
 
-      - name: Commit updated CHANGELOG
-        uses: stefanzweifel/git-auto-commit-action@v7
+      # main's branch ruleset requires every change to go through a pull request,
+      # so the changelog update is opened as a PR rather than pushed directly.
+      - name: Open changelog PR
+        uses: peter-evans/create-pull-request@v7
         with:
-          branch: main
-          commit_message: Update CHANGELOG
-          file_pattern: CHANGELOG.md
+          # A PAT makes the PR's required status checks run (and lets it
+          # auto-merge). PRs opened with the default GITHUB_TOKEN don't trigger
+          # CI, so without RELEASE_PAT a maintainer has to merge it manually.
+          token: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
+          base: main
+          branch: changelog/${{ inputs.tag || github.ref_name }}
+          add-paths: CHANGELOG.md
+          commit-message: "docs: update changelog for ${{ inputs.tag || github.ref_name }}"
+          title: "docs: update changelog for ${{ inputs.tag || github.ref_name }}"
+          body: |
+            Automated changelog update for **${{ inputs.tag || github.ref_name }}**.
+
+            The release workflow can't commit to `main` directly (the branch
+            ruleset requires a pull request), so it opens this with the
+            generated release notes instead.
+          delete-branch: true


### PR DESCRIPTION
## Problem

The `release.yml` job creates the GitHub release, regenerates `CHANGELOG.md`, then commits it **directly to `main`** using a deploy key. But `main`'s branch-protection ruleset requires *every* change to go through a PR:

```
remote: - Changes must be made through a pull request.
remote: ! [remote rejected] HEAD -> main (push declined due to repository rule violations)
```

So the final step fails on every release (v0.6 and v0.7 both failed here — **after** the release + tag were already published, so releases still went out, but the changelog never landed and the run shows red).

## Fix

Replace the direct-push step (`stefanzweifel/git-auto-commit-action`) with `peter-evans/create-pull-request`, which opens a **changelog PR** that satisfies the ruleset. The deploy-key checkout is no longer needed and was removed.

## One prerequisite for full automation

PRs opened with the default `GITHUB_TOKEN` don't trigger `pull_request` workflows, so the required status checks wouldn't run and the changelog PR couldn't auto-merge. The step uses `token: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}`:

- **With a `RELEASE_PAT` secret** (a PAT with `repo` scope, or a GitHub App token): checks run and the PR can auto-merge — fully hands-off.
- **Without it**: the PR is still opened correctly; a maintainer just merges it (it's a docs-only change).

Alternatively, the automation identity could be added to the ruleset's bypass list and the old direct-push flow kept — but opening a PR is the more ruleset-friendly approach.

The v0.7 changelog itself is being landed separately in #44.