### PR TITLE
docs: add v0.8 changelog + grant release workflow pull-requests: write

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   release:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to `Esi` will be documented in this file.
 
+## v0.8 - 2026-07-12
+
+### What's Changed
+* fix: relax EsiToken::delete()/update() return types to mixed by @NicolasKion in https://github.com/NicolasKion/Esi/pull/46
+* ci: open a changelog PR from the release workflow instead of pushing to main by @NicolasKion in https://github.com/NicolasKion/Esi/pull/45
+* docs: add v0.7 changelog entry by @NicolasKion in https://github.com/NicolasKion/Esi/pull/44
+
+
+**Full Changelog**: https://github.com/NicolasKion/Esi/compare/v0.7...v0.8
+
 ## v0.7 - 2026-07-12
 
 ### What's Changed


### PR DESCRIPTION
## Context

`v0.8` is **published** (release + tag + Packagist). The release workflow's changelog step failed once more — this time `create-pull-request` returned `Resource not accessible by integration`, because the job only declared `contents: write`.

## This PR

1. **Adds the v0.8 changelog entry** (the automation couldn't land it), from the generated release notes.
2. **Adds `pull-requests: write`** to `release.yml` so the workflow's token is allowed to open the changelog PR.

## Still required for full automation

`pull-requests: write` is necessary but not sufficient. Creating a PR from `GITHUB_TOKEN` also requires **one** of:

- **Repo setting** *Settings → Actions → General → Workflow permissions → "Allow GitHub Actions to create and approve pull requests"* enabled, **or**
- a **`RELEASE_PAT`** secret (PAT with `repo` scope, or a GitHub App token) — the workflow already prefers it (`token: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}`), which also lets the changelog PR's checks run so it can auto-merge.

I did not change repo settings or add secrets — those are your call. Happy to enable the setting via API if you want.