### PR TITLE
fix: drop native return type from EsiToken::delete()/update()

### DIFF
--- a/src/Interfaces/EsiToken.php
+++ b/src/Interfaces/EsiToken.php
@@ -13,16 +13,21 @@ interface EsiToken
     public function getAccessToken(): string;
 
     /**
-     * The return value is ignored by the library; implementers may return
-     * whatever their storage layer does (e.g. Eloquent's bool).
+     * The return value is ignored by the library, so the return type is left
+     * unconstrained: implementers may return whatever their storage layer does
+     * (e.g. Eloquent's bool), or nothing at all.
+     *
+     * @return mixed
      */
-    public function delete(): mixed;
+    public function delete();
 
     /**
-     * The return value is ignored by the library; implementers may return
-     * whatever their storage layer does (e.g. Eloquent's bool).
+     * The return value is ignored by the library, so the return type is left
+     * unconstrained: implementers may return whatever their storage layer does
+     * (e.g. Eloquent's bool), or nothing at all.
      *
      * @param  array<string, mixed>  $data
+     * @return mixed
      */
-    public function update(array $data): mixed;
+    public function update(array $data);
 }

--- a/tests/ContactsTest.php
+++ b/tests/ContactsTest.php
@@ -30,15 +30,9 @@ function fakeContactCharacter(): Character
             return 'access';
         }
 
-        public function delete(): mixed
-        {
-            return null;
-        }
+        public function delete(): void {}
 
-        public function update(array $data): mixed
-        {
-            return null;
-        }
+        public function update(array $data): void {}
     };
 
     return new class($token) implements Character

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -73,15 +73,9 @@ function fakeCharacter(int $id = 123, int $corporationId = 456): Character
             return 'access';
         }
 
-        public function delete(): mixed
-        {
-            return null;
-        }
+        public function delete(): void {}
 
-        public function update(array $data): mixed
-        {
-            return null;
-        }
+        public function update(array $data): void {}
     };
 
     return new class($token, $id, $corporationId) implements Character
@@ -138,19 +132,15 @@ function trackedToken(bool $expired = false): EsiToken
             return 'access-token';
         }
 
-        public function delete(): mixed
+        public function delete(): void
         {
             $this->deleted = true;
-
-            return null;
         }
 
-        public function update(array $data): mixed
+        public function update(array $data): void
         {
             $this->updated = $data;
             $this->expired = false;
-
-            return null;
         }
     };
 }


### PR DESCRIPTION
## Why

v0.8 (#46) widened `EsiToken::delete()`/`update()` from `: void` to `: mixed` so Eloquent token models (which return `bool`/`?bool`) could implement the interface. But `mixed` is still restrictive — PHP treats it invariantly against `void` and untyped methods:

| implementer declares… | `: void` | `: mixed` | **no type (this PR)** |
|---|---|---|---|
| `: bool` / `: ?bool` (Eloquent) | ❌ | ✅ | ✅ |
| `: void` | ✅ | ❌ | ✅ |
| no return type | ✅ | ❌ | ✅ |

## Change

Remove the native return type entirely and document it with `@return mixed` in PHPDoc (keeps PHPStan level 9 clean). This is the maximally permissive form — every implementation shape now satisfies the interface — and it's actually *more* backward-compatible than `: mixed` was, since it doesn't break the original `: void` implementers.

Test doubles restored to plain `: void` to exercise that path.

## Notes
- **pint** does not re-add a native type — the preset has no `phpdoc_to_return_type`/`return_type_declaration` rule; verified `pint` makes no changes.
- Verified: PHPStan level 9 clean, 332 tests pass.
- This is the third signature tweak to these two methods; it's the final/most-permissive form. Minor bump → next release.