### PR TITLE
feat: accept DTOs for mail recipients and fitting items instead of raw arrays

### DIFF
--- a/src/DTO/FittingItem.php
+++ b/src/DTO/FittingItem.php
@@ -14,6 +14,18 @@ readonly class FittingItem extends Dto
         public int $type_id,
     ) {}
 
+    /**
+     * @return array<string, mixed>
+     */
+    public function __serialize(): array
+    {
+        return [
+            'flag' => $this->flag,
+            'quantity' => $this->quantity,
+            'type_id' => $this->type_id,
+        ];
+    }
+
     public static function fromData(Data $data): self
     {
         return new self(

--- a/src/Esi.php
+++ b/src/Esi.php
@@ -54,6 +54,7 @@ use NicolasKion\Esi\DTO\DogmaEffect;
 use NicolasKion\Esi\DTO\DogmaItem;
 use NicolasKion\Esi\DTO\EsiResult;
 use NicolasKion\Esi\DTO\EveMail;
+use NicolasKion\Esi\DTO\EveMailRecipient;
 use NicolasKion\Esi\DTO\Facility;
 use NicolasKion\Esi\DTO\Faction;
 use NicolasKion\Esi\DTO\FactionWarfareCharacterLeaderboard;
@@ -63,6 +64,7 @@ use NicolasKion\Esi\DTO\FactionWarfareLeaderboard;
 use NicolasKion\Esi\DTO\FactionWarfareSystem;
 use NicolasKion\Esi\DTO\FactionWarfareWar;
 use NicolasKion\Esi\DTO\Fitting;
+use NicolasKion\Esi\DTO\FittingItem;
 use NicolasKion\Esi\DTO\Fleet;
 use NicolasKion\Esi\DTO\FleetInfo;
 use NicolasKion\Esi\DTO\FleetMember;
@@ -966,7 +968,7 @@ class Esi
     /**
      * Sends a mail to a character.
      *
-     * @param  array<int, array<string, mixed>>  $recipients
+     * @param  array<int, EveMailRecipient>  $recipients
      * @return EsiResult<int>
      */
     public function sendMail(Character $character, array $recipients, string $subject, string $body): EsiResult
@@ -2851,7 +2853,7 @@ class Esi
     /**
      * Creates a new ship fitting for a character.
      *
-     * @param  array<int, array<string, mixed>>  $items
+     * @param  array<int, FittingItem>  $items
      * @return EsiResult<int> Returns an instance of EsiResult that contains the new fitting's ID.
      */
     public function createFitting(Character $character, string $name, string $description, int $ship_type_id, array $items): EsiResult

--- a/src/Requests/CreateFittingRequest.php
+++ b/src/Requests/CreateFittingRequest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NicolasKion\Esi\Requests;
 
 use Illuminate\Http\Client\Response;
+use NicolasKion\Esi\DTO\FittingItem;
 use NicolasKion\Esi\Enums\RequestMethod;
 use NicolasKion\Esi\Interfaces\WithBody;
 use NicolasKion\Esi\Request;
@@ -16,7 +17,7 @@ use NicolasKion\Esi\Support\Data;
 class CreateFittingRequest extends Request implements WithBody
 {
     /**
-     * @param  array<int, array<string, mixed>>  $items
+     * @param  array<int, FittingItem>  $items
      */
     public function __construct(
         public int $character_id,
@@ -33,7 +34,7 @@ class CreateFittingRequest extends Request implements WithBody
     {
         return [
             'description' => $this->description,
-            'items' => $this->items,
+            'items' => array_map(static fn (FittingItem $item): array => $item->__serialize(), $this->items),
             'name' => $this->name,
             'ship_type_id' => $this->ship_type_id,
         ];

--- a/src/Requests/SendMailRequest.php
+++ b/src/Requests/SendMailRequest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace NicolasKion\Esi\Requests;
 
 use Illuminate\Http\Client\Response;
+use NicolasKion\Esi\DTO\EveMailRecipient;
 use NicolasKion\Esi\Enums\RequestMethod;
 use NicolasKion\Esi\Interfaces\WithBody;
 use NicolasKion\Esi\Request;
@@ -15,7 +16,7 @@ use NicolasKion\Esi\Request;
 class SendMailRequest extends Request implements WithBody
 {
     /**
-     * @param  array<int, array<string, mixed>>  $recipients
+     * @param  array<int, EveMailRecipient>  $recipients
      */
     public function __construct(public int $sender_id, public array $recipients, public string $subject, public string $body) {}
 
@@ -27,7 +28,7 @@ class SendMailRequest extends Request implements WithBody
         return [
             'approved_cost' => 0,
             'body' => $this->body,
-            'recipients' => $this->recipients,
+            'recipients' => array_map(static fn (EveMailRecipient $recipient): array => $recipient->__serialize(), $this->recipients),
             'subject' => $this->subject,
         ];
     }

--- a/tests/CalendarFittingsPiUiTest.php
+++ b/tests/CalendarFittingsPiUiTest.php
@@ -10,6 +10,7 @@ use NicolasKion\Esi\DTO\CalendarEventAttendee;
 use NicolasKion\Esi\DTO\CalendarEventSummary;
 use NicolasKion\Esi\DTO\CustomsOffice;
 use NicolasKion\Esi\DTO\Fitting;
+use NicolasKion\Esi\DTO\FittingItem;
 use NicolasKion\Esi\DTO\PlanetColony;
 use NicolasKion\Esi\DTO\PlanetLayout;
 use NicolasKion\Esi\Esi;
@@ -188,7 +189,7 @@ it('creates a fitting and returns the new fitting id', function (): void {
     ]);
 
     $items = [
-        ['flag' => 'HiSlot0', 'quantity' => 1, 'type_id' => 2],
+        new FittingItem('HiSlot0', 1, 2),
     ];
 
     $result = (new Esi)->createFitting(fakeCharacter(), 'Ratting Fit', 'A cheap ratting fit', 3, $items);
@@ -200,7 +201,9 @@ it('creates a fitting and returns the new fitting id', function (): void {
         && str_contains($request->url(), '/characters/123/fittings/')
         && $request->data() === [
             'description' => 'A cheap ratting fit',
-            'items' => $items,
+            'items' => [
+                ['flag' => 'HiSlot0', 'quantity' => 1, 'type_id' => 2],
+            ],
             'name' => 'Ratting Fit',
             'ship_type_id' => 3,
         ]);

--- a/tests/MailTest.php
+++ b/tests/MailTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Illuminate\Support\Facades\Http;
 use NicolasKion\Esi\DTO\EveMail;
+use NicolasKion\Esi\DTO\EveMailRecipient;
 use NicolasKion\Esi\Enums\RecipientType;
 use NicolasKion\Esi\Esi;
 
@@ -55,7 +56,7 @@ it('sends a mail and returns the new mail id', function (): void {
     ]);
 
     $recipients = [
-        ['recipient_id' => 90000001, 'recipient_type' => 'character'],
+        new EveMailRecipient(90000001, RecipientType::Character),
     ];
 
     $result = (new Esi)->sendMail(fakeCharacter(), $recipients, 'Test subject', 'Test body');
@@ -68,7 +69,9 @@ it('sends a mail and returns the new mail id', function (): void {
         && $request->data() === [
             'approved_cost' => 0,
             'body' => 'Test body',
-            'recipients' => $recipients,
+            'recipients' => [
+                ['recipient_id' => 90000001, 'recipient_type' => 'character'],
+            ],
             'subject' => 'Test subject',
         ]);
 });


### PR DESCRIPTION
## Why

`sendMail()` and `createFitting()` were the only two write methods still taking **raw structured arrays** (`array<int, array<string, mixed>>`) for their inputs, even though a DTO already existed for each and is used on the response side:

- mail recipients → **`EveMailRecipient`** (already had a `__serialize()` returning the ESI body shape, and a dedicated test)
- fitting items → **`FittingItem`**

Every other `array` input on the API is a flat scalar list (IDs/names), which stays as-is.

## Change

- `sendMail()` / `SendMailRequest`: `$recipients` is now `array<int, EveMailRecipient>`; the body maps each through `__serialize()`.
- `createFitting()` / `CreateFittingRequest`: `$items` is now `array<int, FittingItem>`; added `FittingItem::__serialize()` (mirroring `EveMailRecipient`), body maps through it.
- Tests updated to construct DTOs; the serialized request bodies are unchanged on the wire.

Input-contract change (minor bump). Verified: PHPStan level 9 clean, 332 tests pass.